### PR TITLE
Join-Occlusion for v1.6.x

### DIFF
--- a/src/main/java/games/cubi/raycastedEntityOcclusion/ConfigManager.java
+++ b/src/main/java/games/cubi/raycastedEntityOcclusion/ConfigManager.java
@@ -13,6 +13,7 @@ public class ConfigManager {
     public int raycastRadius;
     public int searchRadius;
     public boolean cullPlayers;
+    public boolean cullPlayersOnJoin;
     public boolean onlyCullSneakingPlayers;
     public int recheckInterval;
     public boolean checkTileEntities;
@@ -28,6 +29,7 @@ public class ConfigManager {
     public static final int RAYCAST_RADIUS_DEFAULT = 48;
     public static final int SEARCH_RADIUS_DEFAULT = 48;
     public static final boolean CULL_PLAYERS_DEFAULT = false;
+    public static final boolean CULL_PLAYERS_ON_JOIN_DEFAULT = false;
     public static final boolean ONLY_CULL_SNEAKING_PLAYERS_DEFAULT = false;
     public static final int RECHECK_INTERVAL_DEFAULT = 50;
     public static final boolean CHECK_TILE_ENTITIES_DEFAULT = true;
@@ -52,6 +54,7 @@ public class ConfigManager {
         raycastRadius = cfg.getInt("raycast-radius", RAYCAST_RADIUS_DEFAULT);
         searchRadius = cfg.getInt("search-radius", SEARCH_RADIUS_DEFAULT);
         cullPlayers = cfg.getBoolean("cull-players", CULL_PLAYERS_DEFAULT);
+        cullPlayers = cfg.getBoolean("cull-players-on-join", CULL_PLAYERS_ON_JOIN_DEFAULT);
         onlyCullSneakingPlayers = cfg.getBoolean("only-cull-sneaking-players", ONLY_CULL_SNEAKING_PLAYERS_DEFAULT);
         recheckInterval = cfg.getInt("recheck-interval", RECHECK_INTERVAL_DEFAULT);
 
@@ -67,6 +70,7 @@ public class ConfigManager {
         cfg.addDefault("raycast-radius", RAYCAST_RADIUS_DEFAULT);
         cfg.addDefault("search-radius", SEARCH_RADIUS_DEFAULT);
         cfg.addDefault("cull-players", CULL_PLAYERS_DEFAULT);
+        cfg.addDefault("cull-players-on-join", CULL_PLAYERS_ON_JOIN_DEFAULT);
         cfg.addDefault("only-cull-sneaking-players", ONLY_CULL_SNEAKING_PLAYERS_DEFAULT);
         cfg.addDefault("recheck-interval", RECHECK_INTERVAL_DEFAULT);
         cfg.addDefault("check-tile-entities", CHECK_TILE_ENTITIES_DEFAULT);

--- a/src/main/java/games/cubi/raycastedEntityOcclusion/EventListener.java
+++ b/src/main/java/games/cubi/raycastedEntityOcclusion/EventListener.java
@@ -84,46 +84,29 @@ public class EventListener implements Listener {
 
     @EventHandler
     public void onPlayerJoin(PlayerJoinEvent event) {
-        if (event.getPlayer().hasPermission("raycastedentityocclusions.updatecheck")) {
-            Player sender = event.getPlayer();
+        Player sender = event.getPlayer();
+
+        if (sender.hasPermission("raycastedentityocclusions.updatecheck")) {
             checkForUpdates(plugin, sender);
+        }
 
-            if (config.cullPlayers) {
-                if (config.cullPlayersOnJoin) {
-                    pendingPlayer.add(sender.getUniqueId());
-                }
-
-                Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                    if (!sender.isOnline()) return;
-
-                    for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-                        if (onlinePlayer.equals(sender)) continue;
-                        sender.hideEntity(plugin, onlinePlayer);
-                        onlinePlayer.hideEntity(plugin, sender);
-                    }
-                }, 20L);
+        if (config.cullPlayers) {
+            if (config.cullPlayersOnJoin) {
+                schedulePlayerOcclusion(sender, 10L);
+                schedulePlayerOcclusion(sender, 100L);
             }
         }
     }
 
-    @EventHandler
-    public void onPlayerMove(PlayerMoveEvent event) {
-        if (config.cullPlayersOnJoin) {
-            Player sender = event.getPlayer();
-            UUID uuid = sender.getUniqueId();
+    private void schedulePlayerOcclusion(Player sender, Long duration) {
+        Bukkit.getScheduler().runTaskLater(plugin, () -> {
+            if (!sender.isOnline()) return;
 
-            if (pendingPlayer.contains(uuid)) {
-                pendingPlayer.remove(uuid);
-                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
-                        if (!sender.isOnline()) return;
-
-                        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
-                            if (onlinePlayer.equals(sender)) continue;
-                            sender.hideEntity(plugin, onlinePlayer);
-                            onlinePlayer.hideEntity(plugin, sender);
-                        }
-                    }, 10L);
+            for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                if (onlinePlayer.equals(sender)) continue;
+                    sender.hideEntity(plugin, onlinePlayer);
+                    onlinePlayer.hideEntity(plugin, sender);
             }
-        }
+        }, duration);
     }
 }

--- a/src/main/java/games/cubi/raycastedEntityOcclusion/EventListener.java
+++ b/src/main/java/games/cubi/raycastedEntityOcclusion/EventListener.java
@@ -10,11 +10,14 @@ import org.bukkit.event.Listener;
 import org.bukkit.event.block.BlockBreakEvent;
 import org.bukkit.event.block.BlockBurnEvent;
 import org.bukkit.event.block.BlockPlaceEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
 import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
 import org.bukkit.event.world.ChunkLoadEvent;
 import org.bukkit.event.world.ChunkUnloadEvent;
 
 import java.util.UUID;
+import java.util.Set;
 
 import static games.cubi.raycastedEntityOcclusion.UpdateChecker.checkForUpdates;
 
@@ -23,6 +26,8 @@ public class EventListener implements Listener {
     private final ConfigManager config;
     private PacketProcessor packetProcessor;
     private final RaycastedEntityOcclusion plugin;
+
+    private final Set<UUID> pendingPlayer = java.util.concurrent.ConcurrentHashMap.newKeySet();
 
     public EventListener(RaycastedEntityOcclusion plugin, ChunkSnapshotManager mgr, ConfigManager cfg) {
         this.manager = mgr;
@@ -73,16 +78,21 @@ public class EventListener implements Listener {
         if (config.packetEventsPresent && packetProcessor != null) {
             UUID player = e.getPlayer().getUniqueId();
             packetProcessor.sendPlayerInfoRemovePacket(player);
+            pendingPlayer.remove(player);
         }
     }
 
     @EventHandler
-    public void onPlayerJoin(org.bukkit.event.player.PlayerJoinEvent event) {
+    public void onPlayerJoin(PlayerJoinEvent event) {
         if (event.getPlayer().hasPermission("raycastedentityocclusions.updatecheck")) {
             Player sender = event.getPlayer();
             checkForUpdates(plugin, sender);
 
             if (config.cullPlayers) {
+                if (config.cullPlayersOnJoin) {
+                    pendingPlayer.add(sender.getUniqueId());
+                }
+
                 Bukkit.getScheduler().runTaskLater(plugin, () -> {
                     if (!sender.isOnline()) return;
 
@@ -91,7 +101,28 @@ public class EventListener implements Listener {
                         sender.hideEntity(plugin, onlinePlayer);
                         onlinePlayer.hideEntity(plugin, sender);
                     }
-                }, 10L);
+                }, 20L);
+            }
+        }
+    }
+
+    @EventHandler
+    public void onPlayerMove(PlayerMoveEvent event) {
+        if (config.cullPlayersOnJoin) {
+            Player sender = event.getPlayer();
+            UUID uuid = sender.getUniqueId();
+
+            if (pendingPlayer.contains(uuid)) {
+                pendingPlayer.remove(uuid);
+                    Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                        if (!sender.isOnline()) return;
+
+                        for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                            if (onlinePlayer.equals(sender)) continue;
+                            sender.hideEntity(plugin, onlinePlayer);
+                            onlinePlayer.hideEntity(plugin, sender);
+                        }
+                    }, 10L);
             }
         }
     }

--- a/src/main/java/games/cubi/raycastedEntityOcclusion/EventListener.java
+++ b/src/main/java/games/cubi/raycastedEntityOcclusion/EventListener.java
@@ -81,6 +81,18 @@ public class EventListener implements Listener {
         if (event.getPlayer().hasPermission("raycastedentityocclusions.updatecheck")) {
             Player sender = event.getPlayer();
             checkForUpdates(plugin, sender);
+
+            if (config.cullPlayers) {
+                Bukkit.getScheduler().runTaskLater(plugin, () -> {
+                    if (!sender.isOnline()) return;
+
+                    for (Player onlinePlayer : Bukkit.getOnlinePlayers()) {
+                        if (onlinePlayer.equals(sender)) continue;
+                        sender.hideEntity(plugin, onlinePlayer);
+                        onlinePlayer.hideEntity(plugin, sender);
+                    }
+                }, 10L);
+            }
         }
     }
 }


### PR DESCRIPTION
**Summary:** This PR implements basic player occlusion on join for v1.6.x. This feature helps ensure that out-of-distance players are never able to see eachother.

**Primary Logic:** Players are hidden immediately upon joining.
**Fallback Mechanism:** Testing showed it is reliable in one task, but I've added a secondary task that triggers 100 ticks after join. This acts as a "failsafe" to ensure players are culled even if the initial packet is missed.

**Configuration:**
Added "cull-players-on-join" (Boolean).
Default: false