### PR TITLE
Add WorldGuard support

### DIFF
--- a/core/src/main/java/games/cubi/raycastedantiesp/core/engine/SimpleEngine.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/engine/SimpleEngine.java
@@ -18,7 +18,10 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.UUID;
+import java.util.function.BiPredicate;
+import java.util.function.Consumer;
 import java.util.function.IntSupplier;
+import java.util.function.Predicate;
 import java.util.function.Supplier;
 
 public class SimpleEngine implements Engine {
@@ -26,12 +29,30 @@ public class SimpleEngine implements Engine {
     private final ParticleSpawner particleSpawner;
     private final Supplier<Collection<PlayerData>> playerSupplier;
     private final IntSupplier currentTickSupplier;
+    private final Predicate<PlayerData> viewerActivationPredicate;
+    private final BiPredicate<PlayerData, Locatable> targetActivationPredicate;
+    private final Consumer<PlayerData> viewerInactiveHandler;
 
     public SimpleEngine(ConfigManager config, ParticleSpawner particleSpawner, Supplier<Collection<PlayerData>> playerSupplier, IntSupplier currentTickSupplier) {
+        this(config, particleSpawner, playerSupplier, currentTickSupplier, ignored -> true, (ignored, target) -> true, ignored -> {});
+    }
+
+    public SimpleEngine(
+            ConfigManager config,
+            ParticleSpawner particleSpawner,
+            Supplier<Collection<PlayerData>> playerSupplier,
+            IntSupplier currentTickSupplier,
+            Predicate<PlayerData> viewerActivationPredicate,
+            BiPredicate<PlayerData, Locatable> targetActivationPredicate,
+            Consumer<PlayerData> viewerInactiveHandler
+    ) {
         this.config = config;
         this.particleSpawner = particleSpawner;
         this.playerSupplier = playerSupplier;
         this.currentTickSupplier = currentTickSupplier;
+        this.viewerActivationPredicate = viewerActivationPredicate;
+        this.targetActivationPredicate = targetActivationPredicate;
+        this.viewerInactiveHandler = viewerInactiveHandler;
     }
 
     @Override
@@ -65,7 +86,10 @@ public class SimpleEngine implements Engine {
                                        boolean debugParticles, int currentTick) {
 
         for (PlayerData playerData : playerDataList) {
-            if (playerData.hasBypassPermission()) continue;
+            if (playerData.hasBypassPermission() || !viewerActivationPredicate.test(playerData)) {
+                viewerInactiveHandler.accept(playerData);
+                continue;
+            }
 
             BlockView blockView = playerData.blockView();
 
@@ -93,6 +117,10 @@ public class SimpleEngine implements Engine {
                         + " tick=" + currentTick);
                 continue;
             }
+            if (!targetActivationPredicate.test(player, entityLocation)) {
+                entityView.setVisibility(entityUUID, true, currentTick);
+                continue;
+            }
             boolean canSee = RaycastUtil.raycast(player, playerLocation, entityLocation, entityConfig.getMaxOccludingCount(), entityConfig.getAlwaysShowRadius(), entityConfig.getRaycastRadius(), debugParticles, blockView, 1, particleSpawner);
             entityView.setVisibility(entityUUID, canSee, currentTick);
         }
@@ -111,6 +139,10 @@ public class SimpleEngine implements Engine {
                         + " tick=" + currentTick);
                 continue;
             }
+            if (!targetActivationPredicate.test(player, otherPlayerLocation)) {
+                playerView.setVisibility(otherPlayerUUID, true, currentTick);
+                continue;
+            }
             boolean canSee = RaycastUtil.raycast(player, playerLocation, otherPlayerLocation, playerConfig.getMaxOccludingCount(), playerConfig.getAlwaysShowRadius(), playerConfig.getRaycastRadius(), debugParticles, blockView, 1, particleSpawner);
             playerView.setVisibility(otherPlayerUUID, canSee, currentTick);
         }
@@ -119,6 +151,10 @@ public class SimpleEngine implements Engine {
     private void checkTileEntities(PlayerData player, Locatable playerLocation, PlatformTileEntityConfig<?> tileEntityConfig, boolean debugParticles, BlockView blockView, int currentTick) {
         for (BlockLocatable tileEntityLocation : blockView.getNeedingRecheck(tileEntityConfig.getVisibleRecheckIntervalTicks(), currentTick)) {
             if (tileEntityLocation.world() == null || !tileEntityLocation.world().equals(playerLocation.world())) {
+                continue;
+            }
+            if (!targetActivationPredicate.test(player, tileEntityLocation)) {
+                blockView.setVisibility(tileEntityLocation, true, currentTick);
                 continue;
             }
 

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewController.java
@@ -46,6 +46,14 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
 
     protected abstract int getHiddenBlockId(int blockY);
 
+    protected boolean isViewerCullingEnabled(PlayerData playerData) {
+        return true;
+    }
+
+    protected boolean shouldApplyCulling(PlayerData playerData, BlockLocatable targetLocation) {
+        return true;
+    }
+
     public void removeViewer(UUID viewerUUID) {
     }
 
@@ -72,7 +80,7 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
         handleBlockPackets(event, event.getUser(), playerData, world, currentTick);
 
         if (playerData.blockView().hasPendingTransitions()) {
-            processTileEntityTransitions(event.getUser(), playerData.blockView());
+            processTileEntityTransitions(event.getUser(), playerData, playerData.blockView(), currentTick);
         }
         event.getUser().flushPackets();
     }
@@ -101,7 +109,9 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
                 ImmutableBlockLocatable location = new ImmutableBlockLocatable(world, change.getX(), change.getY(), change.getZ());
                 if (tileEntity) {
                     blockView.insertTileEntityIfAbsent(location, blockID);
-                    if (!blockView.isVisible(location, currentTick)) {
+                    if (!isViewerCullingEnabled(playerData) || !shouldApplyCulling(playerData, location)) {
+                        markTileEntityVisible(blockView, location, currentTick);
+                    } else if (!blockView.isVisible(location, currentTick)) {
                         change.setBlockId(getHiddenBlockId(location.blockY()));
                         event.markForReEncode(true);
                     }
@@ -114,7 +124,9 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
             ImmutableBlockLocatable location = new ImmutableBlockLocatable(world, packet.getPosition().getX(), packet.getPosition().getY(), packet.getPosition().getZ());
             blockView.insertTileEntityIfAbsent(location, packet.getBlockEntityType().getId(event.getUser().getPacketVersion()));
             ensureTileReplayData(getTrackedTileEntity(blockView, location)).setBlockEntityData(packet.getBlockEntityType(), packet.getNBT());
-            if (!blockView.isVisible(location, currentTick)) {
+            if (!isViewerCullingEnabled(playerData) || !shouldApplyCulling(playerData, location)) {
+                markTileEntityVisible(blockView, location, currentTick);
+            } else if (!blockView.isVisible(location, currentTick)) {
                 event.setCancelled(true);
                 sendHiddenBlock(viewer, location);
             }
@@ -167,16 +179,25 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
         }
     }
 
-    private void processTileEntityTransitions(User viewer, BlockView blockView) {
+    private void processTileEntityTransitions(User viewer, PlayerData playerData, BlockView blockView, int currentTick) {
         for (BlockViewTransition transition : blockView.drainTransitions()) {
             BlockLocatable location = transition.location();
             TileEntityLocatable<PacketEventsTileEntityReplayData> state = getTrackedTileEntity(blockView, location);
 
             switch (transition.type()) {
-                case HIDE -> viewer.writePacketSilently(new WrapperPlayServerBlockChange(
-                        new Vector3i(location.blockX(), location.blockY(), location.blockZ()),
-                        getHiddenBlockId(location.blockY())
-                ));
+                case HIDE -> {
+                    if (!isViewerCullingEnabled(playerData) || !shouldApplyCulling(playerData, location)) {
+                        if (state != null) {
+                            state.setVisible(true);
+                            state.setLastChecked(currentTick);
+                        }
+                        continue;
+                    }
+                    viewer.writePacketSilently(new WrapperPlayServerBlockChange(
+                            new Vector3i(location.blockX(), location.blockY(), location.blockZ()),
+                            getHiddenBlockId(location.blockY())
+                    ));
+                }
                 case SHOW -> {
                     if (state == null || state.blockID() == 0) {
                         continue;
@@ -204,7 +225,9 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
         playerData.blockView().upsertBlock(world, position.getX(), position.getY(), position.getZ(), occluding);
         if (tileEntity) {
             playerData.blockView().insertTileEntityIfAbsent(location, blockID);
-            if (!playerData.blockView().isVisible(location, currentTick)) {
+            if (!isViewerCullingEnabled(playerData) || !shouldApplyCulling(playerData, location)) {
+                markTileEntityVisible(playerData.blockView(), location, currentTick);
+            } else if (!playerData.blockView().isVisible(location, currentTick)) {
                 event.setCancelled(true);
                 sendHiddenBlock(viewer, location);
             }
@@ -262,7 +285,11 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
                             ImmutableBlockLocatable location = new ImmutableBlockLocatable(worldID, blockX, blockY, blockZ);
                             tileEntities.add(location);
                             blockView.insertTileEntityIfAbsent(location, blockID);
-                            section.set(localX, localY, localZ, getHiddenBlockId(blockY));
+                            if (!isViewerCullingEnabled(playerData) || !shouldApplyCulling(playerData, location)) {
+                                markTileEntityVisible(blockView, location, currentTickSupplier.getAsInt());
+                            } else {
+                                section.set(localX, localY, localZ, getHiddenBlockId(blockY));
+                            }
                         }
                     }
                 }
@@ -378,6 +405,15 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
 
     private Vector3i copyBlockVector(Vector3i vector) {
         return new Vector3i(vector.getX(), vector.getY(), vector.getZ());
+    }
+
+    private void markTileEntityVisible(BlockView blockView, BlockLocatable location, int currentTick) {
+        TileEntityLocatable<PacketEventsTileEntityReplayData> trackedTileEntity = getTrackedTileEntity(blockView, location);
+        if (trackedTileEntity == null) {
+            return;
+        }
+        trackedTileEntity.setVisible(true);
+        trackedTileEntity.setLastChecked(currentTick);
     }
 
     @SuppressWarnings("unchecked")

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
@@ -60,6 +60,14 @@ public abstract class PacketEventsEntityViewController implements PacketListener
 
     protected abstract int getHiddenBlockId(int blockY);
 
+    protected boolean isViewerCullingEnabled(PlayerData playerData) {
+        return true;
+    }
+
+    protected boolean shouldApplyCulling(PlayerData playerData, PacketEventsEntity targetEntity) {
+        return true;
+    }
+
     public void removeViewer(UUID viewerUUID) {
     }
 
@@ -83,11 +91,11 @@ public abstract class PacketEventsEntityViewController implements PacketListener
         handleEntityPackets(event, event.getUser(), playerData, world, currentTick);
 
         if (playerData.entityView().hasPendingTransitions()) {
-            processEntityTransitions(viewerUUID, event.getUser(), cast(playerData.entityView()), false);
+            processEntityTransitions(viewerUUID, event.getUser(), playerData, cast(playerData.entityView()), false);
         }
 
         if (playerData.playerView().hasPendingTransitions()) {
-            processEntityTransitions(viewerUUID, event.getUser(), cast(playerData.playerView()), true);
+            processEntityTransitions(viewerUUID, event.getUser(), playerData, cast(playerData.playerView()), true);
         }
         
         event.getUser().flushPackets();
@@ -111,7 +119,8 @@ public abstract class PacketEventsEntityViewController implements PacketListener
             WrapperPlayServerPlayerInfoRemove packet = new WrapperPlayServerPlayerInfoRemove(event);
             List<UUID> remaining = new ArrayList<>();
             for (UUID targetUUID : packet.getProfileIds()) {
-                if (playerData.playerView().isVisible(targetUUID, currentTick)) {
+                PacketEventsEntity entity = cast(playerData.playerView().getEntity(targetUUID));
+                if (entity == null || !shouldApplyCulling(playerData, entity) || playerData.playerView().isVisible(targetUUID, currentTick)) {
                     remaining.add(targetUUID);
                 }
             }
@@ -147,7 +156,10 @@ public abstract class PacketEventsEntityViewController implements PacketListener
                     .setVelocity(packet.getVelocity().getX(), packet.getVelocity().getY(), packet.getVelocity().getZ())
                     .setMetadata(copyEntityMetadata(packet.getEntityMetadata()))
                     .setOnGround(true);
-            if (!entity.visible()) {
+            if (!shouldApplyCulling(playerData, entity)) {
+                entity.setVisible(true).setLastChecked(currentTick);
+                entity.setClientVisible(true);
+            } else if (!entity.visible()) {
                 entity.setClientVisible(false);
                 event.setCancelled(true);
             } else {
@@ -176,7 +188,10 @@ public abstract class PacketEventsEntityViewController implements PacketListener
                     .setHeadYaw(packet.getHeadYaw())
                     .setVelocity(velocity.getX(), velocity.getY(), velocity.getZ())
                     .setOnGround(true);
-            if (!entity.visible()) {
+            if (!shouldApplyCulling(playerData, entity)) {
+                entity.setVisible(true).setLastChecked(currentTick);
+                entity.setClientVisible(true);
+            } else if (!entity.visible()) {
                 entity.setClientVisible(false);
                 event.setCancelled(true);
             } else {
@@ -197,7 +212,10 @@ public abstract class PacketEventsEntityViewController implements PacketListener
                     .setHeadYaw(0.0F)
                     .setVelocity(0.0, 0.0, 0.0)
                     .setOnGround(true);
-            if (!entity.visible()) {
+            if (!shouldApplyCulling(playerData, entity)) {
+                entity.setVisible(true).setLastChecked(currentTick);
+                entity.setClientVisible(true);
+            } else if (!entity.visible()) {
                 entity.setClientVisible(false);
                 event.setCancelled(true);
             } else {
@@ -219,7 +237,10 @@ public abstract class PacketEventsEntityViewController implements PacketListener
                     .setVelocity(0.0, 0.0, 0.0)
                     .setMetadata(copyEntityMetadata(packet.getEntityMetadata()))
                     .setOnGround(true);
-            if (!entity.visible()) {
+            if (!shouldApplyCulling(playerData, entity)) {
+                entity.setVisible(true).setLastChecked(currentTick);
+                entity.setClientVisible(true);
+            } else if (!entity.visible()) {
                 entity.setClientVisible(false);
                 event.setCancelled(true);
             } else {
@@ -327,7 +348,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
         }
         lookup.view().moveRelative(entityID, deltaX, deltaY, deltaZ, currentTick);
         lookup.entity().setOnGround(onGround);
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -350,7 +371,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
         }
         lookup.view().moveRelative(entityID, deltaX, deltaY, deltaZ, currentTick);
         lookup.entity().setYaw(yaw).setPitch(pitch).setOnGround(onGround);
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -366,7 +387,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
                 .setPitch(packet.getPitch())
                 .setVelocity(packet.getDeltaMovement().getX(), packet.getDeltaMovement().getY(), packet.getDeltaMovement().getZ())
                 .setOnGround(packet.isOnGround());
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -388,7 +409,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
                 .setPitch(packet.getValues().getPitch())
                 .setVelocity(packet.getValues().getDeltaMovement().getX(), packet.getValues().getDeltaMovement().getY(), packet.getValues().getDeltaMovement().getZ())
                 .setOnGround(packet.isOnGround());
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -399,7 +420,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
             return;
         }
         lookup.entity().setYaw(yaw).setPitch(pitch).setOnGround(onGround);
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -410,7 +431,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
             return;
         }
         lookup.entity().setHeadYaw(headYaw);
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -422,7 +443,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
         }
         lookup.entity().setMetadata(copyEntityMetadata(packet.getEntityMetadata()));
         ensureReplayData(lookup.entity()).setMetadataPacket(copyEntityMetadataPacket(packet));
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -434,7 +455,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
         }
         lookup.entity().setEquipment(copyEquipment(packet.getEquipment()));
         ensureReplayData(lookup.entity()).setEquipmentPacket(copyEntityEquipmentPacket(packet));
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -446,7 +467,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
         }
         lookup.entity().setVelocity(packet.getVelocity().getX(), packet.getVelocity().getY(), packet.getVelocity().getZ());
         ensureReplayData(lookup.entity()).setVelocityPacket(copyEntityVelocityPacket(packet));
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -457,7 +478,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
             return;
         }
         ensureReplayData(lookup.entity()).addEffectPacket(copyEffectPacket(packet));
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -469,7 +490,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
         }
         lookup.entity().setPassengerIDs(packet.getPassengers().clone());
         ensureReplayData(lookup.entity()).setPassengersPacket(copySetPassengersPacket(packet));
-        if (!lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
+        if (!ensureEntityIsClientVisible(event, playerData, lookup, currentTick) && !lookup.view().isVisible(lookup.entity().entityUUID(), currentTick)) {
             event.setCancelled(true);
         }
     }
@@ -484,7 +505,7 @@ public abstract class PacketEventsEntityViewController implements PacketListener
                 continue;
             }
 
-            boolean visible = lookup.view().isVisible(lookup.entity().entityUUID(), currentTick);
+            boolean visible = !shouldApplyCulling(playerData, lookup.entity()) || lookup.view().isVisible(lookup.entity().entityUUID(), currentTick);
             boolean clientVisible = lookup.entity().clientVisible();
             lookup.view().removeEntity(entityID, currentTick);
 
@@ -503,12 +524,21 @@ public abstract class PacketEventsEntityViewController implements PacketListener
         }
     }
 
-    private void processEntityTransitions(UUID viewerUUID, User viewer, EntityView<PacketEventsEntity> entityView, boolean playerTargets) {
+    private void processEntityTransitions(UUID viewerUUID, User viewer, PlayerData playerData, EntityView<PacketEventsEntity> entityView, boolean playerTargets) {
         for (EntityViewTransition transition : entityView.drainTransitions()) {
             PacketEventsEntity entity = getTrackedEntity(entityView, transition.targetUUID());
 
             switch (transition.type()) {
                 case HIDE -> {
+                    if (entity != null && !shouldApplyCulling(playerData, entity)) {
+                        entity.setVisible(true);
+                        if (!entity.clientVisible() && entity.entityID() >= 0) {
+                            PacketEventsEntityReplayData replayData = ensureReplayData(entity);
+                            sendEntityShow(viewer, entity, replayData, playerTargets);
+                            entity.setClientVisible(true);
+                        }
+                        continue;
+                    }
                     if (entity != null && entity.clientVisible() && entity.entityID() >= 0) {
                         viewer.writePacketSilently(new WrapperPlayServerDestroyEntities(entity.entityID()));
                         entity.setClientVisible(false);
@@ -528,6 +558,20 @@ public abstract class PacketEventsEntityViewController implements PacketListener
                 }
             }
         }
+    }
+
+    private boolean ensureEntityIsClientVisible(PacketSendEvent event, PlayerData playerData, EntityLookup lookup, int currentTick) {
+        if (shouldApplyCulling(playerData, lookup.entity())) {
+            return false;
+        }
+
+        lookup.entity().setVisible(true).setLastChecked(currentTick);
+        if (!lookup.entity().clientVisible() && lookup.entity().entityID() >= 0) {
+            PacketEventsEntityReplayData replayData = ensureReplayData(lookup.entity());
+            sendEntityShow(event.getUser(), lookup.entity(), replayData, lookup.view() == playerData.playerView());
+            lookup.entity().setClientVisible(true);
+        }
+        return true;
     }
 
     private EntityLookup lookupEntity(PlayerData playerData, int entityID) {

--- a/platform-paper/build.gradle.kts
+++ b/platform-paper/build.gradle.kts
@@ -10,6 +10,7 @@ plugins {
 
 repositories {
     mavenCentral()
+    maven { url = uri("https://maven.enginehub.org/repo/") }
     maven { url = uri("https://repo.codemc.io/repository/maven-releases/") }
     maven { url = uri("https://repo.codemc.io/repository/maven-snapshots/") }
 }
@@ -17,6 +18,7 @@ repositories {
 dependencies {
     paperweight.paperDevBundle("1.20.6-R0.1-SNAPSHOT")
     compileOnly("com.github.retrooper:packetevents-spigot:2.8.0")
+    compileOnly("com.sk89q.worldguard:worldguard-bukkit:7.0.13")
     compileOnly("org.spongepowered:configurate-core:4.2.0")
     compileOnly("org.spongepowered:configurate-yaml:4.2.0")
 

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/RaycastedAntiESP.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/RaycastedAntiESP.java
@@ -5,6 +5,8 @@ import com.mojang.brigadier.tree.LiteralCommandNode;
 import games.cubi.raycastedantiesp.core.Core;
 import games.cubi.raycastedantiesp.paper.config.PaperTileEntityConfig;
 import games.cubi.raycastedantiesp.paper.engine.PaperSimpleEngine;
+import games.cubi.raycastedantiesp.paper.worldguard.RegionActivationService;
+import games.cubi.raycastedantiesp.paper.worldguard.WorldGuardRegionActivationService;
 import games.cubi.raycastedantiesp.packetevents.view.PacketEventsBlockView;
 import games.cubi.raycastedantiesp.packetevents.view.PacketEventsEntityView;
 import games.cubi.raycastedantiesp.core.view.ViewRegistry;
@@ -34,6 +36,7 @@ public final class RaycastedAntiESP extends JavaPlugin implements CommandExecuto
     private static MovementTracker tracker;
     private static PaperPacketEventsEntityViewController packetEventsController;
     private static PaperSimpleEngine engine;
+    private static RegionActivationService regionActivationService;
     private static MetricsCollector metricsCollector;
     private static RaycastedAntiESP instance;
 
@@ -55,6 +58,7 @@ public final class RaycastedAntiESP extends JavaPlugin implements CommandExecuto
     @Override
     public void onLoad() {
         config = ConfigManager.initialiseConfigManager(getResource("config.yml"), getDataFolder().toPath(), new PaperTileEntityConfig.Factory.FactoryProvider());
+        initialiseWorldGuardSupport();
         Plugin packetEvents = Bukkit.getPluginManager().getPlugin("packetevents");
         if (packetEvents == null) {
             throw new IllegalStateException("PacketEvents is required but was not found.");
@@ -75,6 +79,7 @@ public final class RaycastedAntiESP extends JavaPlugin implements CommandExecuto
         ViewRegistry.initialise(PacketEventsBlockView::new, PacketEventsEntityView::new);
         packetEventsController = new PaperPacketEventsEntityViewController(currentTickSupplier);
         new PaperPacketEventsBlockViewController(currentTickSupplier);
+        regionActivationService.start();
 
         tracker = new MovementTracker(this, config);
         engine = new PaperSimpleEngine(this, config, currentTickSupplier);
@@ -89,6 +94,7 @@ public final class RaycastedAntiESP extends JavaPlugin implements CommandExecuto
 
     @Override
     public void onDisable() {
+        regionActivationService.stop();
         metricsCollector.shutdown();
     }
 
@@ -118,10 +124,25 @@ public final class RaycastedAntiESP extends JavaPlugin implements CommandExecuto
     public static PaperPacketEventsEntityViewController getPacketEventsController() {
         return packetEventsController;
     }
+    public static RegionActivationService getRegionActivationService() {
+        return regionActivationService;
+    }
     public static PaperSimpleEngine getEngine() {
         return engine;
     }
     public static RaycastedAntiESP get() {
         return instance;
+    }
+
+    private void initialiseWorldGuardSupport() {
+        boolean worldGuardPresent = Bukkit.getPluginManager().getPlugin("WorldGuard") != null;
+        if (worldGuardPresent) {
+            boolean registered = WorldGuardRegionActivationService.registerFlags();
+            if (registered) {
+                Logger.info("WorldGuard detected. Registered flags '" + WorldGuardRegionActivationService.ENABLED_FLAG_NAME + "' and '" + WorldGuardRegionActivationService.DISABLED_FLAG_NAME + "'.", 4, RaycastedAntiESP.class);
+            }
+        }
+
+        regionActivationService = WorldGuardRegionActivationService.create(() -> false);
     }
 }

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/engine/PaperSimpleEngine.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/engine/PaperSimpleEngine.java
@@ -2,26 +2,53 @@ package games.cubi.raycastedantiesp.paper.engine;
 
 import games.cubi.raycastedantiesp.core.config.ConfigManager;
 import games.cubi.raycastedantiesp.core.engine.Engine;
+import games.cubi.raycastedantiesp.core.players.PlayerData;
 import games.cubi.raycastedantiesp.core.players.PlayerRegistry;
+import games.cubi.raycastedantiesp.core.view.BlockView;
+import games.cubi.raycastedantiesp.core.view.EntityView;
 import games.cubi.raycastedantiesp.paper.PaperParticleSpawner;
 import games.cubi.raycastedantiesp.paper.RaycastedAntiESP;
+import games.cubi.raycastedantiesp.paper.worldguard.RegionActivationService;
+import games.cubi.locatables.BlockLocatable;
+import games.cubi.locatables.Locatable;
 import io.papermc.paper.threadedregions.scheduler.AsyncScheduler;
 import org.bukkit.scheduler.BukkitScheduler;
 
+import java.util.UUID;
 import java.util.function.IntSupplier;
 
 public class PaperSimpleEngine implements Engine {
     private final AsyncScheduler asyncScheduler;
     private final BukkitScheduler bukkitScheduler;
     private final RaycastedAntiESP plugin;
+    private final IntSupplier currentTickSupplier;
     //private final BukkitESM entitySnapshotManager;
     private final games.cubi.raycastedantiesp.core.engine.SimpleEngine delegate;
 
     public PaperSimpleEngine(RaycastedAntiESP plugin, ConfigManager cfg, IntSupplier currentTickSupplier) {
         this.plugin = plugin;
+        this.currentTickSupplier = currentTickSupplier;
         asyncScheduler = plugin.getServer().getAsyncScheduler();
         bukkitScheduler = plugin.getServer().getScheduler();
-        delegate = new games.cubi.raycastedantiesp.core.engine.SimpleEngine(cfg, new PaperParticleSpawner(), PlayerRegistry.getInstance()::getAllPlayerData, currentTickSupplier);
+        delegate = new games.cubi.raycastedantiesp.core.engine.SimpleEngine(
+                cfg,
+                new PaperParticleSpawner(),
+                PlayerRegistry.getInstance()::getAllPlayerData,
+                currentTickSupplier,
+                this::isViewerCullingEnabled,
+                this::shouldCullTarget,
+                playerData -> restoreViewerVisibility(playerData, currentTickSupplier.getAsInt())
+        );
+        RaycastedAntiESP.getRegionActivationService().addListener(new RegionActivationService.Listener() {
+            @Override
+            public void onPlayerEnteredEnabledRegion(UUID playerUUID) {
+            }
+
+            @Override
+            public void onPlayerExitedEnabledRegion(UUID playerUUID) {
+                restoreViewerVisibility(playerUUID);
+            }
+        });
 
         //forceEntityLocationUpdate();
     }
@@ -29,6 +56,54 @@ public class PaperSimpleEngine implements Engine {
     @Override
     public void tick() {
         delegate.tick();
+    }
+
+    private boolean isViewerCullingEnabled(PlayerData playerData) {
+        if (playerData == null || playerData.hasBypassPermission()) {
+            return false;
+        }
+        Locatable ownLocation = playerData.ownLocation();
+        if (ownLocation == null || ownLocation.world() == null) {
+            return false;
+        }
+        return RaycastedAntiESP.getRegionActivationService().isEnabled(ownLocation);
+    }
+
+    private boolean shouldCullTarget(PlayerData playerData, Locatable targetLocation) {
+        if (targetLocation == null || targetLocation.world() == null) {
+            return false;
+        }
+        Locatable ownLocation = playerData.ownLocation();
+        if (ownLocation == null || ownLocation.world() == null) {
+            return false;
+        }
+        return RaycastedAntiESP.getRegionActivationService().isEnabled(ownLocation, targetLocation);
+    }
+
+    private void restoreViewerVisibility(UUID playerUUID) {
+        PlayerData playerData = PlayerRegistry.getInstance().getPlayerData(playerUUID);
+        if (playerData == null) {
+            return;
+        }
+        restoreViewerVisibility(playerData, currentTickSupplier.getAsInt());
+    }
+
+    private void restoreViewerVisibility(PlayerData playerData, int currentTick) {
+        restoreEntityView(playerData.entityView(), currentTick);
+        restoreEntityView(playerData.playerView(), currentTick);
+        restoreBlockView(playerData.blockView(), currentTick);
+    }
+
+    private void restoreEntityView(EntityView<?> entityView, int currentTick) {
+        for (UUID entityUUID : entityView.getKnownEntities()) {
+            entityView.setVisibility(entityUUID, true, currentTick);
+        }
+    }
+
+    private void restoreBlockView(BlockView blockView, int currentTick) {
+        for (BlockLocatable location : blockView.getKnownTileEntities()) {
+            blockView.setVisibility(location, true, currentTick);
+        }
     }
 /*
     private void forceEntityLocationUpdate() {  //todo: Quite frankly idk if this is needed, disabled for now since the config option doesn't even exist

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/packets/PaperPacketEventsBlockViewController.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/packets/PaperPacketEventsBlockViewController.java
@@ -3,6 +3,9 @@ package games.cubi.raycastedantiesp.paper.packets;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import com.github.retrooper.packetevents.protocol.player.User;
+import games.cubi.locatables.BlockLocatable;
+import games.cubi.locatables.Locatable;
+import games.cubi.raycastedantiesp.core.players.PlayerData;
 import games.cubi.raycastedantiesp.packetevents.viewcontrollers.PacketEventsBlockViewController;
 import games.cubi.raycastedantiesp.paper.RaycastedAntiESP;
 import games.cubi.raycastedantiesp.paper.staging.PacketEventsPaperBlockInfoResolver;
@@ -45,6 +48,30 @@ public class PaperPacketEventsBlockViewController extends PacketEventsBlockViewC
     @Override
     protected int getHiddenBlockId(int blockY) {
         return blockY > 0 ? stoneBlockId : deepslateBlockId;
+    }
+
+    @Override
+    protected boolean isViewerCullingEnabled(PlayerData playerData) {
+        if (playerData == null || playerData.hasBypassPermission()) {
+            return false;
+        }
+        if (!RaycastedAntiESP.getConfigManager().getTileEntityConfig().isEnabled()) {
+            return false;
+        }
+        Locatable ownLocation = playerData.ownLocation();
+        if (ownLocation == null || ownLocation.world() == null) {
+            return false;
+        }
+        return RaycastedAntiESP.getRegionActivationService().isEnabled(ownLocation);
+    }
+
+    @Override
+    protected boolean shouldApplyCulling(PlayerData playerData, BlockLocatable targetLocation) {
+        if (!isViewerCullingEnabled(playerData) || targetLocation == null || targetLocation.world() == null) {
+            return false;
+        }
+        Locatable ownLocation = playerData.ownLocation();
+        return ownLocation != null && RaycastedAntiESP.getRegionActivationService().isEnabled(ownLocation, targetLocation);
     }
 
     @EventHandler

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/packets/PaperPacketEventsEntityViewController.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/packets/PaperPacketEventsEntityViewController.java
@@ -3,6 +3,10 @@ package games.cubi.raycastedantiesp.paper.packets;
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
 import com.github.retrooper.packetevents.protocol.player.User;
+import games.cubi.locatables.Locatable;
+import games.cubi.raycastedantiesp.core.locatables.EntityLocatable;
+import games.cubi.raycastedantiesp.core.players.PlayerData;
+import games.cubi.raycastedantiesp.packetevents.locatables.PacketEventsEntity;
 import games.cubi.raycastedantiesp.packetevents.viewcontrollers.PacketEventsEntityViewController;
 import games.cubi.raycastedantiesp.paper.RaycastedAntiESP;
 import io.github.retrooper.packetevents.util.SpigotConversionUtil;
@@ -44,6 +48,35 @@ public class PaperPacketEventsEntityViewController extends PacketEventsEntityVie
     @Override
     protected int getHiddenBlockId(int blockY) {
         return blockY > 0 ? stoneBlockId : deepslateBlockId;
+    }
+
+    @Override
+    protected boolean isViewerCullingEnabled(PlayerData playerData) {
+        if (playerData == null || playerData.hasBypassPermission()) {
+            return false;
+        }
+        Locatable ownLocation = playerData.ownLocation();
+        if (ownLocation == null || ownLocation.world() == null) {
+            return false;
+        }
+        return RaycastedAntiESP.getRegionActivationService().isEnabled(ownLocation);
+    }
+
+    @Override
+    protected boolean shouldApplyCulling(PlayerData playerData, PacketEventsEntity targetEntity) {
+        if (!isViewerCullingEnabled(playerData) || targetEntity == null || targetEntity.world() == null) {
+            return false;
+        }
+
+        boolean checkEnabled = targetEntity.spawnType() == EntityLocatable.SpawnType.PLAYER
+                ? RaycastedAntiESP.getConfigManager().getPlayerConfig().isEnabled()
+                : RaycastedAntiESP.getConfigManager().getEntityConfig().isEnabled();
+        if (!checkEnabled) {
+            return false;
+        }
+
+        Locatable ownLocation = playerData.ownLocation();
+        return ownLocation != null && RaycastedAntiESP.getRegionActivationService().isEnabled(ownLocation, targetEntity);
     }
 
     @EventHandler

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/worldguard/NoOpRegionActivationService.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/worldguard/NoOpRegionActivationService.java
@@ -1,0 +1,35 @@
+package games.cubi.raycastedantiesp.paper.worldguard;
+
+import games.cubi.locatables.Locatable;
+
+import java.util.Objects;
+import java.util.function.BooleanSupplier;
+
+public final class NoOpRegionActivationService implements RegionActivationService {
+    private final BooleanSupplier defaultEnabledSupplier;
+
+    public NoOpRegionActivationService(BooleanSupplier defaultEnabledSupplier) {
+        this.defaultEnabledSupplier = Objects.requireNonNull(defaultEnabledSupplier, "defaultEnabledSupplier");
+    }
+
+    @Override
+    public boolean isEnabled(Locatable locatable) {
+        return locatable != null && locatable.world() != null && defaultEnabledSupplier.getAsBoolean();
+    }
+
+    @Override
+    public void addListener(Listener listener) {
+    }
+
+    @Override
+    public void removeListener(Listener listener) {
+    }
+
+    @Override
+    public void start() {
+    }
+
+    @Override
+    public void stop() {
+    }
+}

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/worldguard/RegionActivationService.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/worldguard/RegionActivationService.java
@@ -1,0 +1,27 @@
+package games.cubi.raycastedantiesp.paper.worldguard;
+
+import games.cubi.locatables.Locatable;
+
+import java.util.UUID;
+
+public interface RegionActivationService {
+    boolean isEnabled(Locatable locatable);
+
+    default boolean isEnabled(Locatable first, Locatable second) {
+        return isEnabled(first) && isEnabled(second);
+    }
+
+    void addListener(Listener listener);
+
+    void removeListener(Listener listener);
+
+    void start();
+
+    void stop();
+
+    interface Listener {
+        void onPlayerEnteredEnabledRegion(UUID playerUUID);
+
+        void onPlayerExitedEnabledRegion(UUID playerUUID);
+    }
+}

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/worldguard/WorldGuardRegionActivationService.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/worldguard/WorldGuardRegionActivationService.java
@@ -1,0 +1,266 @@
+package games.cubi.raycastedantiesp.paper.worldguard;
+
+import com.sk89q.worldedit.bukkit.BukkitAdapter;
+import com.sk89q.worldguard.WorldGuard;
+import com.sk89q.worldguard.protection.ApplicableRegionSet;
+import com.sk89q.worldguard.protection.flags.Flag;
+import com.sk89q.worldguard.protection.flags.StateFlag;
+import com.sk89q.worldguard.protection.flags.registry.FlagConflictException;
+import com.sk89q.worldguard.protection.flags.registry.FlagRegistry;
+import games.cubi.locatables.Locatable;
+import games.cubi.logs.Logger;
+import games.cubi.raycastedantiesp.paper.locatables.LocatableAdapterUtils;
+import games.cubi.raycastedantiesp.paper.utils.PaperListener;
+import org.bukkit.Bukkit;
+import org.bukkit.Location;
+import org.bukkit.entity.Player;
+import org.bukkit.event.EventHandler;
+import org.bukkit.event.EventPriority;
+import org.bukkit.event.HandlerList;
+import org.bukkit.event.player.PlayerChangedWorldEvent;
+import org.bukkit.event.player.PlayerJoinEvent;
+import org.bukkit.event.player.PlayerMoveEvent;
+import org.bukkit.event.player.PlayerQuitEvent;
+import org.bukkit.event.player.PlayerRespawnEvent;
+import org.bukkit.event.player.PlayerTeleportEvent;
+
+import java.util.Objects;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.BooleanSupplier;
+
+public final class WorldGuardRegionActivationService implements RegionActivationService {
+    public static final String ENABLED_FLAG_NAME = "raycasted-antiesp-enabled";
+    public static final String DISABLED_FLAG_NAME = "raycasted-antiesp-disabled";
+
+    private static volatile StateFlag enabledFlag;
+    private static volatile StateFlag disabledFlag;
+
+    private final BooleanSupplier defaultEnabledSupplier;
+    private final CopyOnWriteArrayList<Listener> listeners = new CopyOnWriteArrayList<>();
+    private final ConcurrentHashMap<UUID, Boolean> playerStates = new ConcurrentHashMap<>();
+    private final AtomicBoolean started = new AtomicBoolean(false);
+    private final Object queryLock = new Object();
+
+    private volatile PlayerStateListener playerStateListener;
+
+    private WorldGuardRegionActivationService(BooleanSupplier defaultEnabledSupplier) {
+        this.defaultEnabledSupplier = Objects.requireNonNull(defaultEnabledSupplier, "defaultEnabledSupplier");
+    }
+
+    public static RegionActivationService create(BooleanSupplier defaultEnabledSupplier) {
+        if (Bukkit.getPluginManager().getPlugin("WorldGuard") == null) {
+            return new NoOpRegionActivationService(defaultEnabledSupplier);
+        }
+        if (enabledFlag == null || disabledFlag == null) {
+            Logger.warning("WorldGuard is present, but activation flags were not registered. Falling back to default activation behaviour.", 2, WorldGuardRegionActivationService.class);
+            return new NoOpRegionActivationService(defaultEnabledSupplier);
+        }
+
+        return new WorldGuardRegionActivationService(defaultEnabledSupplier);
+    }
+
+    public static boolean registerFlags() {
+        FlagRegistry registry = WorldGuard.getInstance().getFlagRegistry();
+        StateFlag registeredEnabledFlag = resolveOrRegisterFlag(registry, ENABLED_FLAG_NAME);
+        StateFlag registeredDisabledFlag = resolveOrRegisterFlag(registry, DISABLED_FLAG_NAME);
+
+        if (registeredEnabledFlag == null || registeredDisabledFlag == null) {
+            return false;
+        }
+
+        enabledFlag = registeredEnabledFlag;
+        disabledFlag = registeredDisabledFlag;
+        return true;
+    }
+
+    private static StateFlag resolveOrRegisterFlag(FlagRegistry registry, String flagName) {
+        try {
+            StateFlag flag = new StateFlag(flagName, false);
+            registry.register(flag);
+            return flag;
+        } catch (FlagConflictException e) {
+            Flag<?> existing = registry.get(flagName);
+            if (existing instanceof StateFlag stateFlag) {
+                Logger.warning("WorldGuard flag '" + flagName + "' is already registered; reusing it.", 4, WorldGuardRegionActivationService.class);
+                return stateFlag;
+            }
+
+            Logger.error(new IllegalStateException("Conflicting WorldGuard flag '" + flagName + "' exists with a different type.", e), 1, WorldGuardRegionActivationService.class);
+            return null;
+        }
+    }
+
+    @Override
+    public boolean isEnabled(Locatable locatable) {
+        if (locatable == null || locatable.world() == null) {
+            return false;
+        }
+
+        Location location = LocatableAdapterUtils.toBukkitLocation(locatable);
+        if (location.getWorld() == null) {
+            return false;
+        }
+
+        return computeEnabled(location);
+    }
+
+    @Override
+    public boolean isEnabled(Locatable first, Locatable second) {
+        if (first == null || second == null) {
+            return false;
+        }
+        synchronized (queryLock) {
+            return isEnabled(first) && isEnabled(second);
+        }
+    }
+
+    @Override
+    public void addListener(Listener listener) {
+        listeners.add(Objects.requireNonNull(listener, "listener"));
+    }
+
+    @Override
+    public void removeListener(Listener listener) {
+        listeners.remove(listener);
+    }
+
+    @Override
+    public void start() {
+        if (!started.compareAndSet(false, true)) {
+            return;
+        }
+
+        playerStateListener = new PlayerStateListener(this);
+        for (Player player : Bukkit.getOnlinePlayers()) {
+            refreshPlayerState(player.getUniqueId(), player.getLocation());
+        }
+    }
+
+    @Override
+    public void stop() {
+        if (!started.compareAndSet(true, false)) {
+            return;
+        }
+
+        PlayerStateListener existingListener = playerStateListener;
+        if (existingListener != null) {
+            HandlerList.unregisterAll(existingListener);
+            playerStateListener = null;
+        }
+
+        listeners.clear();
+        playerStates.clear();
+    }
+
+    private boolean computeEnabled(Location location) {
+        synchronized (queryLock) {
+            ApplicableRegionSet regions = WorldGuard.getInstance()
+                    .getPlatform()
+                    .getRegionContainer()
+                    .createQuery()
+                    .getApplicableRegions(BukkitAdapter.adapt(location));
+
+            if (regions.testState(null, disabledFlag)) {
+                return false;
+            }
+            if (regions.testState(null, enabledFlag)) {
+                return true;
+            }
+
+            return defaultEnabledSupplier.getAsBoolean();
+        }
+    }
+
+    private void refreshPlayerState(UUID playerUUID, Location location) {
+        if (location == null || location.getWorld() == null) {
+            return;
+        }
+
+        boolean enabled = computeEnabled(location);
+        Boolean previous = playerStates.put(playerUUID, enabled);
+        if (previous == null) {
+            if (enabled) {
+                notifyEnter(playerUUID);
+            }
+            return;
+        }
+        if (previous == enabled) {
+            return;
+        }
+
+        if (enabled) {
+            notifyEnter(playerUUID);
+        } else {
+            notifyExit(playerUUID);
+        }
+    }
+
+    private void removePlayerState(UUID playerUUID) {
+        playerStates.remove(playerUUID);
+    }
+
+    private void notifyEnter(UUID playerUUID) {
+        for (Listener listener : listeners) {
+            listener.onPlayerEnteredEnabledRegion(playerUUID);
+        }
+    }
+
+    private void notifyExit(UUID playerUUID) {
+        for (Listener listener : listeners) {
+            listener.onPlayerExitedEnabledRegion(playerUUID);
+        }
+    }
+
+    private static final class PlayerStateListener extends PaperListener {
+        private final WorldGuardRegionActivationService service;
+
+        private PlayerStateListener(WorldGuardRegionActivationService service) {
+            this.service = service;
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        public void onPlayerJoin(PlayerJoinEvent event) {
+            service.refreshPlayerState(event.getPlayer().getUniqueId(), event.getPlayer().getLocation());
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR)
+        public void onPlayerQuit(PlayerQuitEvent event) {
+            service.removePlayerState(event.getPlayer().getUniqueId());
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onPlayerMove(PlayerMoveEvent event) {
+            Location from = event.getFrom();
+            Location to = event.getTo();
+            if (to == null) {
+                return;
+            }
+            if (from.getWorld() != null && from.getWorld().equals(to.getWorld())
+                    && from.getBlockX() == to.getBlockX()
+                    && from.getBlockY() == to.getBlockY()
+                    && from.getBlockZ() == to.getBlockZ()) {
+                return;
+            }
+
+            service.refreshPlayerState(event.getPlayer().getUniqueId(), to);
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onPlayerTeleport(PlayerTeleportEvent event) {
+            service.refreshPlayerState(event.getPlayer().getUniqueId(), event.getTo());
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onPlayerChangedWorld(PlayerChangedWorldEvent event) {
+            service.refreshPlayerState(event.getPlayer().getUniqueId(), event.getPlayer().getLocation());
+        }
+
+        @EventHandler(priority = EventPriority.MONITOR, ignoreCancelled = true)
+        public void onPlayerRespawn(PlayerRespawnEvent event) {
+            service.refreshPlayerState(event.getPlayer().getUniqueId(), event.getRespawnLocation());
+        }
+    }
+}

--- a/platform-paper/src/main/resources/plugin.yml
+++ b/platform-paper/src/main/resources/plugin.yml
@@ -21,4 +21,6 @@ permissions:
         default: false
 depend:
     - packetevents
+softdepend:
+    - WorldGuard
 folia-supported: true


### PR DESCRIPTION
Adds WorldGuard-based activation support.

Included:
- WorldGuard initialization and flag registration
- thread-safe activation API for one or two locatables
- player enter/exit callbacks
- enabled/disabled flags with disabled taking priority on overlaps
- activation-aware engine and packet handling
