### PR TITLE
Disable bypass permission effect

### DIFF
--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/EventListener.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/EventListener.java
@@ -58,8 +58,10 @@ public class EventListener extends PaperListener {
             checkForUpdates(plugin, player);
         }
 
-        boolean hasBypassPermission = player.hasPermission("raycastedantiesp.bypass");
-        playerData.setBypassPermission(hasBypassPermission);
+        if (player.hasPermission("raycastedantiesp.bypass")) {
+            Logger.warning("Player " + player.getName() + " (" + player.getUniqueId() + ") has the raycastedantiesp.bypass permission, but bypassing checks is disabled.", 3, EventListener.class);
+            player.sendMessage(MiniMessage.miniMessage().deserialize("<red><bold>Warning:</bold> You have the <white>raycastedantiesp.bypass</white> permission, but it no longer bypasses anti-ESP checks.</red>"));
+        }
         updateOwnLocation(playerData, player.getEyeLocation());
     }
 
@@ -122,5 +124,4 @@ public class EventListener extends PaperListener {
         Location eyeLocation = location.clone().add(0, player.getEyeHeight(), 0);
         updateOwnLocation(playerData, eyeLocation);
     }
-
 }

--- a/platform-paper/src/main/resources/plugin.yml
+++ b/platform-paper/src/main/resources/plugin.yml
@@ -11,7 +11,7 @@ permissions:
         description: Permission to use the /RaycastedAntiESP command
         default: op
     raycastedantiesp.bypass:
-        description: Permission to bypass all checks. A restart is needed to apply this permission.
+        description: Deprecated permission. It does not bypass anti-ESP checks and holders are warned when they join.
         default: false
     raycastedantiesp.updatecheck:
         description: Permission to check for plugin updates


### PR DESCRIPTION
## What changed
- stop copying `raycastedantiesp.bypass` into player state
- warn permission holders in chat and the server log when they join
- mark the permission as deprecated in `plugin.yml`

## Why
The bypass permission is currently broken and causing issues.

## Impact
Players with the permission are checked like all other players. They receive a clear warning so stale permission assignments can be removed.

## Validation
- traced all repository references to the permission and bypass flag
- confirmed new player data defaults the bypass flag to `false`
- no automated workflow was available for the branch at PR creation time