### PR TITLE
Add entity ID bypasses for excluded types

### DIFF
--- a/core/src/main/java/games/cubi/raycastedantiesp/core/config/ChecksConfig.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/config/ChecksConfig.java
@@ -22,6 +22,7 @@ public record ChecksConfig(PlayerConfig playerConfig, EntityConfig entityConfig,
     public boolean hasRestartOnlyChanges(ChecksConfig startup) {
         return playerConfig.enabled() != startup.playerConfig.enabled()
                 || entityConfig.enabled() != startup.entityConfig.enabled()
+                || !entityConfig.excludedTypes().equals(startup.entityConfig.excludedTypes())
                 || chunkSectionConfig.enabled() != startup.chunkSectionConfig.enabled();
     }
 }

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/config/raycast/EntityConfig.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/config/raycast/EntityConfig.java
@@ -1,15 +1,31 @@
 package games.cubi.raycastedantiesp.core.config.raycast;
 
+import games.cubi.raycastedantiesp.core.config.ConfigReader;
 import org.spongepowered.configurate.ConfigurationNode;
 
+import java.util.List;
+import java.util.Set;
+
 public class EntityConfig extends RaycastConfig {
-    private EntityConfig(RaycastConfig config) {
+    private final Set<String> excludedTypes;
+
+    private EntityConfig(RaycastConfig config, List<String> excludedTypes) {
         super(config.enabled(), config.hideSoundsWhenHidden(), config.getMaxOccludingCount(), config.getAlwaysShowRadius(),
                 config.getRaycastRadius(), config.hideOnSpawnDistance(), config.getVisibleRecheckIntervalTicks(),
                 config.keepClientEntityWhenHidden());
+        this.excludedTypes = Set.copyOf(excludedTypes);
     }
 
     public static EntityConfig load(ConfigurationNode node, String path) {
-        return new EntityConfig(RaycastConfig.load(node, path, true, true));
+        RaycastConfig config = RaycastConfig.load(node, path, true, true);
+        List<String> excludedTypes = ConfigReader.stringList(
+                ConfigReader.node(node, "excluded-types"),
+                path + ".excluded-types"
+        );
+        return new EntityConfig(config, excludedTypes);
+    }
+
+    public Set<String> excludedTypes() {
+        return excludedTypes;
     }
 }

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/config/raycast/EntityTypeExclusions.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/config/raycast/EntityTypeExclusions.java
@@ -1,0 +1,36 @@
+package games.cubi.raycastedantiesp.core.config.raycast;
+
+import it.unimi.dsi.fastutil.ints.IntCollection;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import it.unimi.dsi.fastutil.ints.IntSet;
+import it.unimi.dsi.fastutil.ints.IntSets;
+
+/**
+ * Immutable entity-type exclusion policy resolved during plugin startup.
+ */
+public final class EntityTypeExclusions {
+    private static final EntityTypeExclusions EMPTY = new EntityTypeExclusions(IntSets.emptySet());
+    private static volatile EntityTypeExclusions active = EMPTY;
+
+    private final IntSet excludedTypes;
+
+    private EntityTypeExclusions(IntCollection excludedTypes) {
+        this.excludedTypes = IntSets.unmodifiable(new IntOpenHashSet(excludedTypes));
+    }
+
+    public static void initialise(IntCollection excludedTypes) {
+        active = excludedTypes.isEmpty() ? EMPTY : new EntityTypeExclusions(excludedTypes);
+    }
+
+    public static boolean excludes(int entityType) {
+        return active.excludedTypes.contains(entityType);
+    }
+
+    public static int size() {
+        return active.excludedTypes.size();
+    }
+
+    private EntityTypeExclusions() {
+        this.excludedTypes = IntSets.emptySet();
+    }
+}

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/entity/EntityBypassRegistry.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/entity/EntityBypassRegistry.java
@@ -1,0 +1,29 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright © 2026 Cubicake.
+ * This file is part of RaycastedAntiESP.
+ * RaycastedAntiESP is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License v3.0 only, which can be accessed at https://www.gnu.org/licenses/agpl-3.0.html.
+ * See README.md for warranty disclaimer and further information.
+ */
+
+package games.cubi.raycastedantiesp.core.entity;
+
+import games.cubi.raycastedantiesp.core.utils.AppendingMTIntSet;
+
+/**
+ * Global append-only registry of entity IDs which RaycastedAntiESP must ignore.
+ */
+public final class EntityBypassRegistry {
+    private static final AppendingMTIntSet BYPASSED_ENTITY_IDS = AppendingMTIntSet.get();
+
+    private EntityBypassRegistry() {
+    }
+
+    public static AppendingMTIntSet bypassedEntityIDs() {
+        return BYPASSED_ENTITY_IDS;
+    }
+
+    public static boolean isBypassed(int entityID) {
+        return BYPASSED_ENTITY_IDS.contains(entityID);
+    }
+}

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/utils/AppendingMTIntSet.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/utils/AppendingMTIntSet.java
@@ -1,0 +1,23 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright © 2026 Cubicake.
+ * This file is part of RaycastedAntiESP.
+ * RaycastedAntiESP is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License v3.0 only, which can be accessed at https://www.gnu.org/licenses/agpl-3.0.html.
+ * See README.md for warranty disclaimer and further information.
+ */
+
+package games.cubi.raycastedantiesp.core.utils;
+
+/**
+ * Thread-safe int sets which cannot shrink in size. Hashcode and equals are not implemented.
+ */
+public interface AppendingMTIntSet {
+    boolean contains(int value);
+
+    void add(int value);
+
+    // testing both impls by changing this factory method
+    static AppendingMTIntSet get() {
+        return new IncrementingMTIntSet();
+    }
+}

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/utils/CopyOnWriteIntSet.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/utils/CopyOnWriteIntSet.java
@@ -1,0 +1,41 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright © 2026 Cubicake.
+ * This file is part of RaycastedAntiESP.
+ * RaycastedAntiESP is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License v3.0 only, which can be accessed at https://www.gnu.org/licenses/agpl-3.0.html.
+ * See README.md for warranty disclaimer and further information.
+ */
+
+package games.cubi.raycastedantiesp.core.utils;
+
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+
+import java.lang.invoke.VarHandle;
+
+/**
+ * An append-only multithreaded int set backed by an open-addressing int hash set.
+ * Designed for highly multithreaded reads and rare writes.
+ */
+public class CopyOnWriteIntSet implements AppendingMTIntSet {
+    private volatile IntOpenHashSet backingSet; private static final VarHandle BACKING_SET = VarHandler.get(CopyOnWriteIntSet.class, "backingSet", IntOpenHashSet.class);
+
+    public CopyOnWriteIntSet() {
+        backingSet = new IntOpenHashSet();
+    }
+
+    public boolean contains(int value) {
+        return ((IntOpenHashSet) BACKING_SET.getAcquire(this)).contains(value);
+    }
+
+    public void add(int value) {
+        while (true) {
+            IntOpenHashSet oldSet = (IntOpenHashSet) BACKING_SET.getAcquire(this);
+            if (oldSet.contains(value)) return;
+
+            IntOpenHashSet newSet = oldSet.clone();
+            newSet.add(value);
+            boolean success = BACKING_SET.weakCompareAndSetRelease(this, oldSet, newSet);
+            if (success) return;
+        }
+    }
+}

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/utils/IncrementingMTIntSet.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/utils/IncrementingMTIntSet.java
@@ -1,0 +1,39 @@
+/*
+ * SPDX-License-Identifier: AGPL-3.0-only
+ * Copyright © 2026 Cubicake.
+ * This file is part of RaycastedAntiESP.
+ * RaycastedAntiESP is free software: you can redistribute it and/or modify it under the terms of the GNU Affero General Public License v3.0 only, which can be accessed at https://www.gnu.org/licenses/agpl-3.0.html.
+ * See README.md for warranty disclaimer and further information.
+ */
+
+package games.cubi.raycastedantiesp.core.utils;
+
+import java.lang.invoke.VarHandle;
+import java.util.Arrays;
+
+public class IncrementingMTIntSet implements AppendingMTIntSet {
+    private volatile int[] values = new int[0]; private static final VarHandle VALUES = VarHandler.get(IncrementingMTIntSet.class, "values", int[].class);
+
+    public boolean contains(int value) {
+        int[] valueSnapshot = (int[]) VALUES.getAcquire(this);
+        return Arrays.binarySearch(valueSnapshot, value) >= 0;
+    }
+
+    public void add(int value) {
+        while (true) {
+            int[] oldValues = (int[]) VALUES.getAcquire(this);
+            int result = Arrays.binarySearch(oldValues, value);
+
+            if (result >= 0) return;
+            int[] newValues = new int[oldValues.length + 1];
+            int insertionPoint = -result - 1;
+
+            System.arraycopy(oldValues, 0, newValues, 0, insertionPoint);
+            newValues[insertionPoint] = value;
+            System.arraycopy(oldValues, insertionPoint, newValues, insertionPoint + 1, oldValues.length - insertionPoint);
+
+            boolean success = VALUES.weakCompareAndSetRelease(this, oldValues, newValues);
+            if (success) return;
+        }
+    }
+}

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityView.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityView.java
@@ -4,6 +4,7 @@ import ca.spottedleaf.concurrentutil.collection.MultiThreadedQueue;
 import ca.spottedleaf.concurrentutil.map.SWMRHashTable;
 import games.cubi.locatables.api.Spatial;
 import games.cubi.logs.Logger;
+import games.cubi.raycastedantiesp.core.config.raycast.EntityTypeExclusions;
 import games.cubi.raycastedantiesp.core.tracked.NettyEntity;
 import games.cubi.raycastedantiesp.core.players.PlayerData;
 import games.cubi.raycastedantiesp.core.utils.SingleThreadedGuard;
@@ -201,7 +202,10 @@ public class PacketEventsEntityView extends SingleThreadedGuard implements Entit
             return 0;
         }
         if (countingActuallyNeeded) {
-            return entitiesByUUID.forEachValueCounted( (entity) -> {
+            return entitiesByUUID.forEachValueCounted(entity -> {
+                if (keepExcludedEntityVisible(entity, currentTick, expectedWorldEpoch)) {
+                    return false;
+                }
                 if (entity.visible() && (recheckTicks < 0 || currentTick - entity.lastChecked() < recheckTicks)) {
                     return false;
                 }
@@ -209,13 +213,28 @@ public class PacketEventsEntityView extends SingleThreadedGuard implements Entit
                 return true;
             });
         }
-        entitiesByUUID.forEachValue( (entity) -> {
+        entitiesByUUID.forEachValue(entity -> {
+            if (keepExcludedEntityVisible(entity, currentTick, expectedWorldEpoch)) {
+                return;
+            }
             if (entity.visible() && (recheckTicks < 0 || currentTick - entity.lastChecked() < recheckTicks)) {
                 return;
             }
             action.accept(entity);
         });
         return 0;
+    }
+
+    private boolean keepExcludedEntityVisible(PacketEventsEntity entity, int currentTick, int expectedWorldEpoch) {
+        if (isPlayerView || !EntityTypeExclusions.excludes(entity.entityType())) {
+            return false;
+        }
+        if (entity.visible()) {
+            entity.setLastChecked(currentTick);
+        } else {
+            setVisibility(entity, true, currentTick, expectedWorldEpoch);
+        }
+        return true;
     }
 
     @Override

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/RaycastedAntiESP.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/RaycastedAntiESP.java
@@ -7,11 +7,11 @@
  */
 
 package games.cubi.raycastedantiesp.paper;
-
 import games.cubi.raycastedantiesp.core.Core;
 import games.cubi.raycastedantiesp.paper.commands.Attribution;
 import games.cubi.raycastedantiesp.paper.commands.AttributionBrigadier;
 import games.cubi.raycastedantiesp.paper.commands.RaycastedAntiESPCommandBrigadier;
+import games.cubi.raycastedantiesp.paper.config.PaperEntityTypeExclusionResolver;
 import games.cubi.raycastedantiesp.paper.engine.PaperAsyncEngine;
 import games.cubi.raycastedantiesp.packetevents.config.PacketEventsBlockProcessorConfig;
 import games.cubi.raycastedantiesp.packetevents.view.PacketEventsBlockView;
@@ -91,6 +91,7 @@ public final class RaycastedAntiESP extends JavaPlugin implements CommandExecuto
         else {
             currentTickSupplier = new PaperTicker();
         }
+        PaperEntityTypeExclusionResolver.resolveAndInitialise(config.getEntityConfig().excludedTypes());
         PacketEventsPaperBlockInfoResolver blockInfoResolver = new PacketEventsPaperBlockInfoResolver();
         boolean trackAllBlocks = config.getBlockProcessorConfig().trackAllBlocks();
         ViewRegistry.initialise(worldEpoch -> new PacketEventsBlockView(blockInfoResolver, trackAllBlocks, worldEpoch), PacketEventsEntityView::createEntityView, PacketEventsEntityView::createPlayerView);

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/config/PaperEntityTypeExclusionResolver.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/config/PaperEntityTypeExclusionResolver.java
@@ -1,0 +1,81 @@
+package games.cubi.raycastedantiesp.paper.config;
+
+import com.github.retrooper.packetevents.PacketEvents;
+import com.github.retrooper.packetevents.protocol.entity.type.EntityType;
+import com.github.retrooper.packetevents.protocol.player.ClientVersion;
+import games.cubi.logs.Logger;
+import games.cubi.raycastedantiesp.core.config.raycast.EntityTypeExclusions;
+import io.github.retrooper.packetevents.util.SpigotConversionUtil;
+import it.unimi.dsi.fastutil.ints.IntOpenHashSet;
+import org.bukkit.NamespacedKey;
+import org.bukkit.Registry;
+
+import java.util.Collection;
+import java.util.LinkedHashSet;
+import java.util.Set;
+
+public final class PaperEntityTypeExclusionResolver {
+    private static final String CONFIG_PATH = "checks.entity.excluded-types";
+
+    private PaperEntityTypeExclusionResolver() {}
+
+    public static void resolveAndInitialise(Collection<String> configuredNames) {
+        ClientVersion version = PacketEvents.getAPI().getServerManager().getVersion().toClientVersion();
+        Set<String> normalizedNames = new LinkedHashSet<>();
+        for (String configuredName : configuredNames) {
+            String normalized = normalize(configuredName);
+            if (normalized != null) {
+                normalizedNames.add(normalized);
+            }
+        }
+
+        IntOpenHashSet excludedTypes = new IntOpenHashSet(normalizedNames.size());
+        for (String normalizedName : normalizedNames) {
+            NamespacedKey key = NamespacedKey.fromString(normalizedName);
+            if (key == null) {
+                warn("contains invalid resource name '" + normalizedName + "'");
+                continue;
+            }
+
+            org.bukkit.entity.EntityType paperType = Registry.ENTITY_TYPE.get(key);
+            if (paperType == null) {
+                warn("contains unknown entity type '" + normalizedName + "'");
+                continue;
+            }
+            if (paperType == org.bukkit.entity.EntityType.PLAYER) {
+                warn("cannot exclude player entity type '" + normalizedName + "'");
+                continue;
+            }
+
+            EntityType packetEventsType = SpigotConversionUtil.fromBukkitEntityType(paperType);
+            if (packetEventsType == null) {
+                warn("contains entity type '" + normalizedName + "' which is known to Paper but not PacketEvents");
+                continue;
+            }
+
+            int entityType = packetEventsType.getId(version);
+            if (entityType < 0) {
+                warn("contains entity type '" + normalizedName + "' which has no concrete PacketEvents ID for " + version);
+                continue;
+            }
+            excludedTypes.add(entityType);
+        }
+
+        EntityTypeExclusions.initialise(excludedTypes);
+        Logger.info("Resolved " + EntityTypeExclusions.size() + " excluded entity types.", 5);
+    }
+
+    private static String normalize(String configuredName) {
+        String trimmed = configuredName.trim();
+        if (trimmed.isEmpty()) {
+            warn("contains an empty entry");
+            return null;
+        }
+        return trimmed.indexOf(':') < 0 ? "minecraft:" + trimmed : trimmed;
+    }
+
+    private static void warn(String message) {
+        Logger.warning(CONFIG_PATH + " " + message + ". The entry will be ignored.", 4,
+                PaperEntityTypeExclusionResolver.class);
+    }
+}

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/packets/PaperPacketEventsEntityViewController.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/packets/PaperPacketEventsEntityViewController.java
@@ -10,15 +10,14 @@ package games.cubi.raycastedantiesp.paper.packets;
 
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
-import com.github.retrooper.packetevents.wrapper.PacketWrapper;
-import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnEntity;
-import games.cubi.logs.Logger;
+import com.github.retrooper.packetevents.event.PacketSendEvent;
+import com.github.retrooper.packetevents.protocol.entity.type.EntityTypes;
+import com.github.retrooper.packetevents.protocol.packettype.PacketType;
+import com.github.retrooper.packetevents.wrapper.play.server.*;
 import games.cubi.raycastedantiesp.core.config.raycast.EntityTypeExclusions;
-import games.cubi.raycastedantiesp.core.players.PlayerData;
-import games.cubi.raycastedantiesp.core.tracked.NettyEntity;
+import games.cubi.raycastedantiesp.core.entity.EntityBypassRegistry;
 import games.cubi.raycastedantiesp.packetevents.viewcontrollers.PacketEventsEntityViewController;
 
-import java.util.UUID;
 import java.util.function.IntSupplier;
 
 public class PaperPacketEventsEntityViewController extends PacketEventsEntityViewController {
@@ -29,31 +28,72 @@ public class PaperPacketEventsEntityViewController extends PacketEventsEntityVie
     }
 
     @Override
-    protected boolean handleEntitySpawn(PacketWrapper<?> packet, int entityID, boolean isPlayer,
-                                        PlayerData playerData, UUID world, int currentTick) {
-        if (isPlayer || world == null) {
-            return super.handleEntitySpawn(packet, entityID, isPlayer, playerData, world, currentTick);
+    public void onPacketSend(PacketSendEvent event) {
+        if (shouldBypass(event)) {
+            return;
         }
+        super.onPacketSend(event);
+    }
 
-        WrapperPlayServerSpawnEntity spawnPacket = (WrapperPlayServerSpawnEntity) packet;
-        int entityType = spawnPacket.getEntityType().getId(
+    private boolean shouldBypass(PacketSendEvent event) {
+        return switch (event.getPacketType()) {
+            case PacketType.Play.Server.SPAWN_ENTITY -> shouldBypassSpawn(new WrapperPlayServerSpawnEntity(event));
+            case PacketType.Play.Server.ENTITY_ANIMATION -> isBypassed(new WrapperPlayServerEntityAnimation(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_STATUS -> isBypassed(new WrapperPlayServerEntityStatus(event).getEntityId());
+            case PacketType.Play.Server.HURT_ANIMATION -> isBypassed(new WrapperPlayServerHurtAnimation(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_RELATIVE_MOVE -> isBypassed(new WrapperPlayServerEntityRelativeMove(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_RELATIVE_MOVE_AND_ROTATION -> isBypassed(new WrapperPlayServerEntityRelativeMoveAndRotation(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_TELEPORT -> isBypassed(new WrapperPlayServerEntityTeleport(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_POSITION_SYNC -> isBypassed(new WrapperPlayServerEntityPositionSync(event).getId());
+            case PacketType.Play.Server.ENTITY_ROTATION -> isBypassed(new WrapperPlayServerEntityRotation(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_HEAD_LOOK -> isBypassed(new WrapperPlayServerEntityHeadLook(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_METADATA -> isBypassed(new WrapperPlayServerEntityMetadata(event).getEntityId());
+            case PacketType.Play.Server.REMOVE_ENTITY_EFFECT -> isBypassed(new WrapperPlayServerRemoveEntityEffect(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_EQUIPMENT -> isBypassed(new WrapperPlayServerEntityEquipment(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_VELOCITY -> isBypassed(new WrapperPlayServerEntityVelocity(event).getEntityId());
+            case PacketType.Play.Server.ENTITY_EFFECT -> isBypassed(new WrapperPlayServerEntityEffect(event).getEntityId());
+            case PacketType.Play.Server.UPDATE_ATTRIBUTES -> isBypassed(new WrapperPlayServerUpdateAttributes(event).getEntityId());
+            case PacketType.Play.Server.SET_PASSENGERS -> {
+                WrapperPlayServerSetPassengers packet = new WrapperPlayServerSetPassengers(event);
+                yield isBypassed(packet.getEntityId()) || containsBypassed(packet.getPassengers());
+            }
+            case PacketType.Play.Server.ATTACH_ENTITY -> {
+                WrapperPlayServerAttachEntity packet = new WrapperPlayServerAttachEntity(event);
+                yield isBypassed(packet.getAttachedId()) || isBypassed(packet.getHoldingId());
+            }
+            case PacketType.Play.Server.DESTROY_ENTITIES -> containsBypassed(new WrapperPlayServerDestroyEntities(event).getEntityIds());
+            default -> false;
+        };
+    }
+
+    private boolean shouldBypassSpawn(WrapperPlayServerSpawnEntity packet) {
+        int entityID = packet.getEntityId();
+        if (isBypassed(entityID)) {
+            return true;
+        }
+        if (packet.getEntityType().isInstanceOf(EntityTypes.PLAYER)) {
+            return false;
+        }
+        int entityType = packet.getEntityType().getId(
                 PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()
         );
         if (!EntityTypeExclusions.excludes(entityType)) {
-            return super.handleEntitySpawn(packet, entityID, false, playerData, world, currentTick);
+            return false;
         }
+        EntityBypassRegistry.bypassedEntityIDs().add(entityID);
+        return true;
+    }
 
-        NettyEntity<?> entity = Logger.requireNonNull(
-                processEntitySpawn(playerData, packet, world, currentTick),
-                "processEntitySpawn returned null",
-                3,
-                PaperPacketEventsEntityViewController.class
-        );
-        entity.setVisible(true);
-        entity.setClientVisible(true);
-        entity.setLastChecked(currentTick);
-        insertEntityToEntityView(entity, playerData, world);
-        playerData.nettyData().runPendingPostSpawnTaskForEntity(entityID);
+    private static boolean isBypassed(int entityID) {
+        return EntityBypassRegistry.isBypassed(entityID);
+    }
+
+    private static boolean containsBypassed(int[] entityIDs) {
+        for (int entityID : entityIDs) {
+            if (isBypassed(entityID)) {
+                return true;
+            }
+        }
         return false;
     }
 }

--- a/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/packets/PaperPacketEventsEntityViewController.java
+++ b/platform-paper/src/main/java/games/cubi/raycastedantiesp/paper/packets/PaperPacketEventsEntityViewController.java
@@ -10,15 +10,50 @@ package games.cubi.raycastedantiesp.paper.packets;
 
 import com.github.retrooper.packetevents.PacketEvents;
 import com.github.retrooper.packetevents.event.PacketListenerPriority;
+import com.github.retrooper.packetevents.wrapper.PacketWrapper;
+import com.github.retrooper.packetevents.wrapper.play.server.WrapperPlayServerSpawnEntity;
+import games.cubi.logs.Logger;
+import games.cubi.raycastedantiesp.core.config.raycast.EntityTypeExclusions;
+import games.cubi.raycastedantiesp.core.players.PlayerData;
+import games.cubi.raycastedantiesp.core.tracked.NettyEntity;
 import games.cubi.raycastedantiesp.packetevents.viewcontrollers.PacketEventsEntityViewController;
 
+import java.util.UUID;
 import java.util.function.IntSupplier;
-
 
 public class PaperPacketEventsEntityViewController extends PacketEventsEntityViewController {
 
     public PaperPacketEventsEntityViewController(IntSupplier currentTickSupplier) {
         super(currentTickSupplier);
         PacketEvents.getAPI().getEventManager().registerListener(this, PacketListenerPriority.HIGHEST);
+    }
+
+    @Override
+    protected boolean handleEntitySpawn(PacketWrapper<?> packet, int entityID, boolean isPlayer,
+                                        PlayerData playerData, UUID world, int currentTick) {
+        if (isPlayer || world == null) {
+            return super.handleEntitySpawn(packet, entityID, isPlayer, playerData, world, currentTick);
+        }
+
+        WrapperPlayServerSpawnEntity spawnPacket = (WrapperPlayServerSpawnEntity) packet;
+        int entityType = spawnPacket.getEntityType().getId(
+                PacketEvents.getAPI().getServerManager().getVersion().toClientVersion()
+        );
+        if (!EntityTypeExclusions.excludes(entityType)) {
+            return super.handleEntitySpawn(packet, entityID, false, playerData, world, currentTick);
+        }
+
+        NettyEntity<?> entity = Logger.requireNonNull(
+                processEntitySpawn(playerData, packet, world, currentTick),
+                "processEntitySpawn returned null",
+                3,
+                PaperPacketEventsEntityViewController.class
+        );
+        entity.setVisible(true);
+        entity.setClientVisible(true);
+        entity.setLastChecked(currentTick);
+        insertEntityToEntityView(entity, playerData, world);
+        playerData.nettyData().runPendingPostSpawnTaskForEntity(entityID);
+        return false;
     }
 }

--- a/platform-paper/src/main/resources/config.yml
+++ b/platform-paper/src/main/resources/config.yml
@@ -18,6 +18,7 @@ checks:
         hide-on-spawn-distance: 24
         visible-recheck-interval-ticks: 5
         keep-client-entity-when-hidden: true
+        excluded-types: []
     tile-entity:
         enabled: true
         max-occluding-count: 3


### PR DESCRIPTION
## What changed

- adds `checks.entity.excluded-types` as a restart-only list of resource names
- resolves bare names through the `minecraft` namespace and validates them with Paper's entity registry
- converts validated entity types to PacketEvents primitive type IDs
- rejects player types and warns for invalid, unknown, or unmapped entries
- pulls the `AppendingMTIntSet` interface, factory, and both implementations from `main`
- adds a global `EntityBypassRegistry` backed only through `AppendingMTIntSet.get()`
- adds IDs to that registry when an excluded entity type is observed in a spawn packet
- ignores subsequent entity packets whose IDs are present in the bypass registry
- exposes `EntityBypassRegistry.bypassedEntityIDs()` so external integrations such as FancyNPCs can append IDs later

## Behaviour

Presence in the global bypass set means RaycastedAntiESP ignores packets relating to that entity and does not create normal tracked state for excluded-type spawns. Passenger, attachment, and destroy packets are ignored when they contain a bypassed ID.

The set is intentionally append-only. Entity IDs may later be added independently by FancyNPC lifecycle events through the exposed interface.

## Implementation selection

Consumers depend only on `AppendingMTIntSet`. The concrete implementation remains selected by `AppendingMTIntSet.get()`, allowing either `IncrementingMTIntSet` or `CopyOnWriteIntSet` to be tested without changing bypass consumers.

## Configuration

```yaml
checks:
    entity:
        excluded-types:
            - zombie
            - minecraft:armor_stand
```

Bare names default to `minecraft:`. Changes require a restart.

## Validation

The branch diff was inspected through the GitHub connector. Local Gradle execution is unavailable in this environment because it has no repository checkout or GitHub network access; CI remains the executable validation source.