### PR TITLE
More optimisations

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,6 +3,7 @@
 
 README.md
 *.md
+*.toml
 
 *.iml
 *.ipr

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/engine/AsyncEngine.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/engine/AsyncEngine.java
@@ -382,17 +382,9 @@ public abstract class AsyncEngine implements Engine {
             if (attachedToAlwaysVisibleEntityOrSelf(player, entityView, entity, currentTick, worldEpoch)) {
                 return;
             }
-            ImmutableSpatial entityLocation = entity.getOffsetPosition();
-            if (entityLocation == null) {
-                timings.incrementEntityNullTargets();
-                Logger.debug("checkEntities skipped-null-location viewer=" + player.getPlayerUUID()
-                        + " target=" + entity.entityUUID()
-                        + " wasVisible=" + wasVisible
-                        + " tick=" + currentTick);
-                return;
-            }
+
             timings.incrementEntityRaycasts();
-            boolean canSee = RaycastUtil.raycast(playerLocation, entityLocation, entityConfig.getMaxOccludingCount(), entityConfig.getAlwaysShowRadius(), entityConfig.getRaycastRadius(), debugParticles, blockView, 1, particleSpawner);
+            boolean canSee = RaycastUtil.raycast(playerLocation, entity, entityConfig.getMaxOccludingCount(), entityConfig.getAlwaysShowRadius(), entityConfig.getRaycastRadius(), debugParticles, blockView, entity.getYOffset(), 1, particleSpawner);
             entityView.setVisibility(entity, canSee, currentTick, worldEpoch);
         });
         timings.addEntityChecked(checked);
@@ -406,17 +398,8 @@ public abstract class AsyncEngine implements Engine {
             if (attachedToAlwaysVisibleEntityOrSelf(player, playerView, otherPlayer, currentTick, worldEpoch)) {
                 return;
             }
-            ImmutableSpatial otherPlayerLocation = otherPlayer.getOffsetPosition();
-            if (otherPlayerLocation == null) {
-                timings.incrementPlayerNullTargets();
-                Logger.debug("checkPlayers skipped-null-location viewer=" + player.getPlayerUUID()
-                        + " target=" + otherPlayer.entityUUID()
-                        + " wasVisible=" + wasVisible
-                        + " tick=" + currentTick);
-                return;
-            }
             timings.incrementPlayerRaycasts();
-            boolean canSee = RaycastUtil.raycast(playerLocation, otherPlayerLocation, playerConfig.getMaxOccludingCount(), playerConfig.getAlwaysShowRadius(), playerConfig.getRaycastRadius(), debugParticles, blockView, 1, particleSpawner);
+            boolean canSee = RaycastUtil.raycast(playerLocation, otherPlayer, playerConfig.getMaxOccludingCount(), playerConfig.getAlwaysShowRadius(), playerConfig.getRaycastRadius(), debugParticles, blockView, 1.5f, 1, particleSpawner);
             playerView.setVisibility(otherPlayer, canSee, currentTick, worldEpoch);
         });
         timings.addPlayerChecked(checked);

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/engine/AsyncEngine.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/engine/AsyncEngine.java
@@ -356,20 +356,26 @@ public abstract class AsyncEngine implements Engine {
             }
             timings.incrementProcessedPlayers();
 
-            if (entityConfig.enabled()) {
-                long sectionStartNanos = timings.startEntitySection();
-                checkEntities(playerData, playerLocation, entityConfig, debugParticles, blockView, currentTick, worldEpoch, timings);
-                timings.finishEntitySection(sectionStartNanos);
-            }
-            if (playerConfig.enabled()) {
-                long sectionStartNanos = timings.startPlayerSection();
-                checkPlayers(playerData, playerLocation, playerConfig, debugParticles, blockView, currentTick, worldEpoch, timings);
-                timings.finishPlayerSection(sectionStartNanos);
-            }
-            if (tileEntityConfig.enabled()) {
-                long sectionStartNanos = timings.startTileSection();
-                checkTileEntities(playerData, playerLocation, tileEntityConfig, debugParticles, blockView, currentTick, worldEpoch, timings);
-                timings.finishTileSection(sectionStartNanos);
+            try {
+                if (entityConfig.enabled()) {
+                    long sectionStartNanos = timings.startEntitySection();
+                    checkEntities(playerData, playerLocation, entityConfig, debugParticles, blockView, currentTick, worldEpoch, timings);
+                    timings.finishEntitySection(sectionStartNanos);
+                }
+                if (playerConfig.enabled()) {
+                    long sectionStartNanos = timings.startPlayerSection();
+                    checkPlayers(playerData, playerLocation, playerConfig, debugParticles, blockView, currentTick, worldEpoch, timings);
+                    timings.finishPlayerSection(sectionStartNanos);
+                }
+                if (tileEntityConfig.enabled()) {
+                    long sectionStartNanos = timings.startTileSection();
+                    checkTileEntities(playerData, playerLocation, tileEntityConfig, debugParticles, blockView, currentTick, worldEpoch, timings);
+                    timings.finishTileSection(sectionStartNanos);
+                }
+            } finally {
+                playerData.entityView().flushPendingTransitions();
+                playerData.playerView().flushPendingTransitions();
+                blockView.flushPendingTransitions();
             }
         }
     }

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/engine/TickTimingBatch.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/engine/TickTimingBatch.java
@@ -72,20 +72,12 @@ public class TickTimingBatch {
         entityChecked += count;
     }
 
-    public void incrementEntityNullTargets() {
-        entityNullTargets++;
-    }
-
     public void incrementEntityRaycasts() {
         entityRaycasts++;
     }
 
     public void addPlayerChecked(int count) {
         playerChecked += count;
-    }
-
-    public void incrementPlayerNullTargets() {
-        playerNullTargets++;
     }
 
     public void incrementPlayerRaycasts() {

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/engine/TickTimingSnapshot.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/engine/TickTimingSnapshot.java
@@ -17,10 +17,8 @@ record TickTimingSnapshot(
         int nullLocationSkippedPlayers,
         int entityChecked,
         int entityRaycasts,
-        int entityNullTargets,
         int playerChecked,
         int playerRaycasts,
-        int playerNullTargets,
         int tileChecked,
         int tileRaycasts,
         int tileWorldSkipped,
@@ -44,10 +42,8 @@ record TickTimingSnapshot(
                 + " nullLocationSkippedPlayers=" + nullLocationSkippedPlayers
                 + " entityRecheckCandidates=" + entityChecked
                 + " entityRaycasts=" + entityRaycasts
-                + " entityNullTargets=" + entityNullTargets
                 + " playerRecheckCandidates=" + playerChecked
                 + " playerRaycasts=" + playerRaycasts
-                + " playerNullTargets=" + playerNullTargets
                 + " tileRecheckCandidates=" + tileChecked
                 + " tileRaycasts=" + tileRaycasts
                 + " tileWorldSkipped=" + tileWorldSkipped

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/engine/TickTimings.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/engine/TickTimings.java
@@ -19,11 +19,9 @@ final class TickTimings {
 
     private int entityChecked;
     private int entityRaycasts;
-    private int entityNullTargets;
 
     private int playerChecked;
     private int playerRaycasts;
-    private int playerNullTargets;
 
     private int tileChecked;
     private int tileRaycasts;
@@ -52,11 +50,9 @@ final class TickTimings {
 
         entityChecked += batch.entityChecked;
         entityRaycasts += batch.entityRaycasts;
-        entityNullTargets += batch.entityNullTargets;
 
         playerChecked += batch.playerChecked;
         playerRaycasts += batch.playerRaycasts;
-        playerNullTargets += batch.playerNullTargets;
 
         tileChecked += batch.tileChecked;
         tileRaycasts += batch.tileRaycasts;
@@ -82,10 +78,8 @@ final class TickTimings {
                 nullLocationSkippedPlayers,
                 entityChecked,
                 entityRaycasts,
-                entityNullTargets,
                 playerChecked,
                 playerRaycasts,
-                playerNullTargets,
                 tileChecked,
                 tileRaycasts,
                 tileWorldSkipped,

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/raycast/RaycastUtil.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/raycast/RaycastUtil.java
@@ -15,8 +15,12 @@ public class RaycastUtil {
     //Missing blocks is acceptable, as it will be assumed the player can see past those corners.
     //While this uses objects, JHM and in-game profiling have both shown that all objects used here are consistently scalarised by the JVM.
     public static boolean raycast(Locatable start, Spatial end, int maxOccluding, int alwaysShowRadius, int maxRaycastRadius, boolean debug, BlockView snap, int stepSize, ParticleSpawner particleSpawner) {
+        return raycast(start, end, maxOccluding, alwaysShowRadius, maxRaycastRadius, debug, snap, 0f, stepSize, particleSpawner);
+    }
+
+    public static boolean raycast(Locatable start, Spatial end, int maxOccluding, int alwaysShowRadius, int maxRaycastRadius, boolean debug, BlockView snap, float yOffsetEnd, int stepSize, ParticleSpawner particleSpawner) {
         double endOffset = end instanceof BlockSpatial ? 0.5 : 0.0;
-        MutableFloatingSpatial clonedEnd = new MutableSpatialImpl(end.x() + endOffset, end.y() + endOffset, end.z() + endOffset);
+        MutableFloatingSpatial clonedEnd = new MutableSpatialImpl(end.x() + endOffset, end.y() + endOffset + yOffsetEnd, end.z() + endOffset);
         //Equivalent to end.cloneAndIfBlockThenCentre(); but not used since the JVM was not reliably scalarising that method (probably due to the polymorphic overriding?). This causes 0 object allocations.
         double total = start.distance(clonedEnd) - stepSize; //benchmarking shows that calling distance() is faster than distanceSquared() then checking distanceSquared < stepSize*stepSize every time despite the latter replacing a square root with multiplication
         if (total <= alwaysShowRadius) return true;

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/raycast/RaycastUtil.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/raycast/RaycastUtil.java
@@ -1,5 +1,6 @@
 package games.cubi.raycastedantiesp.core.raycast;
 
+import games.cubi.locatables.api.BlockSpatial;
 import games.cubi.locatables.api.Locatable;
 import games.cubi.locatables.api.MutableFloatingSpatial;
 import games.cubi.locatables.api.Spatial;
@@ -14,7 +15,9 @@ public class RaycastUtil {
     //Missing blocks is acceptable, as it will be assumed the player can see past those corners.
     //While this uses objects, JHM and in-game profiling have both shown that all objects used here are consistently scalarised by the JVM.
     public static boolean raycast(Locatable start, Spatial end, int maxOccluding, int alwaysShowRadius, int maxRaycastRadius, boolean debug, BlockView snap, int stepSize, ParticleSpawner particleSpawner) {
-        MutableFloatingSpatial clonedEnd = end.cloneAndIfBlockThenCentre();
+        double endOffset = end instanceof BlockSpatial ? 0.5 : 0.0;
+        MutableFloatingSpatial clonedEnd = new MutableSpatialImpl(end.x() + endOffset, end.y() + endOffset, end.z() + endOffset);
+        //Equivalent to end.cloneAndIfBlockThenCentre(); but not used since the JVM was not reliably scalarising that method (probably due to the polymorphic overriding?). This causes 0 object allocations.
         double total = start.distance(clonedEnd) - stepSize; //benchmarking shows that calling distance() is faster than distanceSquared() then checking distanceSquared < stepSize*stepSize every time despite the latter replacing a square root with multiplication
         if (total <= alwaysShowRadius) return true;
         if (total > maxRaycastRadius) return false;

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/tracked/NettyEntity.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/tracked/NettyEntity.java
@@ -302,8 +302,8 @@ public abstract class NettyEntity<PacketReplayData extends Clearable> implements
     }
 
     @Override
-    public ImmutableSpatial getOffsetPosition() {
-        return new ImmutableSpatialImpl(x(), y() + 0.5, z()); //todo: move away from hardcoded offset
+    public float getYOffset() {
+        return 0.5f; //todo: move away from hardcoded offset
     }
 
     @Override

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/tracked/TrackedEntity.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/tracked/TrackedEntity.java
@@ -70,7 +70,7 @@ public interface TrackedEntity<PacketReplayData> extends MutableFloatingSpatial 
     PacketReplayData packetReplayData();
     TrackedEntity<?> setPacketReplayData(PacketReplayData packetReplayData);
 
-    ImmutableSpatial getOffsetPosition();
+    float getYOffset();
 
     /**
      * For use when the player disconnects, clears all data.

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/AbstractBlockView.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/AbstractBlockView.java
@@ -1,6 +1,5 @@
 package games.cubi.raycastedantiesp.core.view;
 
-import ca.spottedleaf.concurrentutil.collection.MultiThreadedQueue;
 import ca.spottedleaf.concurrentutil.map.SWMRInt2ObjectHashTable;
 import games.cubi.locatables.api.BlockLocatable;
 import games.cubi.locatables.api.BlockSpatial;
@@ -40,7 +39,7 @@ public abstract class AbstractBlockView<R extends Clearable, T extends NettyTile
      * <p> Since direct access to this object outside {@link AbstractBlockView} is impossible, a marker head object is skipped, and head removal is handled separately.
      * **/
     private final SWMRInt2ObjectHashTable<NettyTileEntity<R>> knownTileEntitiesByColumnBucket = new SWMRInt2ObjectHashTable<>();
-    private final MultiThreadedQueue<BlockViewTransition> transitions = new MultiThreadedQueue<>();
+    private final PackedBlockTransitionQueue transitions = new PackedBlockTransitionQueue();
     private final IntSupplier worldEpochSupplier;
     private volatile UUID trackedWorld;
     // Bit 0 is enabled; higher bits are a generation. The generation prevents enabled -> disabled -> enabled ABA from
@@ -135,15 +134,6 @@ public abstract class AbstractBlockView<R extends Clearable, T extends NettyTile
         return state == null || state.visible();
     }
 
-    @Override
-    public void applyTileEntityVisibilityDecision(TrackedTileEntity<?> tileEntity, boolean visible, int currentTick, long modeToken, int expectedWorldEpoch) {
-        if (!(tileEntity instanceof NettyTileEntity<?> nettyTileEntity)) {
-            return;
-        }
-        @SuppressWarnings("unchecked") T typed = (T) nettyTileEntity;
-        commitTileEntityVisibilityDecision(typed, typed.visible(), visible, currentTick, modeToken, expectedWorldEpoch);
-    }
-
     private void commitTileEntityVisibilityDecision(T tileEntity, boolean currentVisibility, boolean shouldBeVisible, int currentTick, long modeToken, int expectedWorldEpoch) {
         if (!isCurrentWorldEpoch(expectedWorldEpoch) || tileEntityCheckModeTokenAcquire() != modeToken) {
             return;
@@ -155,12 +145,8 @@ public abstract class AbstractBlockView<R extends Clearable, T extends NettyTile
         tileEntity.setVisible(shouldBeVisible);
         tileEntity.setLastChecked(currentTick);
         if (visibilityChanged) {
-            transitions.add(new BlockViewTransition(
-                    shouldBeVisible ? BlockViewTransition.Type.SHOW : BlockViewTransition.Type.HIDE,
-                    tileEntity,
-                    modeToken,
-                    expectedWorldEpoch
-            ));
+            BlockViewTransition.Type type = shouldBeVisible ? BlockViewTransition.Type.SHOW : BlockViewTransition.Type.HIDE;
+            transitions.add(type, tileEntity, modeToken, expectedWorldEpoch);
         }
     }
 
@@ -174,28 +160,29 @@ public abstract class AbstractBlockView<R extends Clearable, T extends NettyTile
     }
 
     @Override
-    public void applyTileEntityCheckMode(boolean enabled, int currentTick) {
+    public Collection<TrackedTileEntity<?>> applyTileEntityCheckMode(boolean enabled, int currentTick) {
         long current = tileEntityCheckModeTokenAcquire();
         if (modeEnabled(current) == enabled) {
-            return;
+            return null;
         }
         // Drop the enabled bit, increment the generation, then restore bit 0 below only for enabled mode.
         long next = ((current >>> 1) + 1L) << 1;
         if (enabled) {
             forEachTileEntity(tileEntity -> tileEntity.setLastChecked(TrackedTileEntity.NEVER_CHECKED));
             TILE_ENTITY_CHECK_MODE_TOKEN.setRelease(this, next | 1L);
-            return;
+            return null;
         }
 
         TILE_ENTITY_CHECK_MODE_TOKEN.setRelease(this, next);
-        int worldEpoch = worldEpochSupplier.getAsInt();
+        ArrayList<TrackedTileEntity<?>> visibilityRepairs = new ArrayList<>();
         forEachTileEntity(tileEntity -> {
-            boolean visible = tileEntity.visible();
-            if (!visible) {
-                @SuppressWarnings("unchecked") T typed = (T) tileEntity;
-                commitTileEntityVisibilityDecision(typed, false, true, currentTick, next, worldEpoch);
+            if (!tileEntity.visible()) {
+                tileEntity.setVisible(true);
+                tileEntity.setLastChecked(currentTick);
+                visibilityRepairs.add(tileEntity);
             }
         });
+        return visibilityRepairs;
     }
 
     @Override
@@ -257,17 +244,17 @@ public abstract class AbstractBlockView<R extends Clearable, T extends NettyTile
 
     @Override
     public boolean hasPendingTransitions() {
-        return !transitions.isEmpty();
+        return transitions.hasPendingTransitions();
     }
 
     @Override
-    public List<BlockViewTransition> drainTransitions() {
-        List<BlockViewTransition> drained = new ArrayList<>();
-        BlockViewTransition transition;
-        while ((transition = transitions.poll()) != null) {
-            drained.add(transition);
-        }
-        return drained;
+    public void flushPendingTransitions() {
+        transitions.flushPendingTransitions();
+    }
+
+    @Override
+    public void drainTransitions(BlockView.TransitionConsumer consumer) {
+        transitions.drainTransitions(consumer);
     }
 
     @Override
@@ -374,7 +361,7 @@ public abstract class AbstractBlockView<R extends Clearable, T extends NettyTile
         chunks.clear();
         forEachTileEntity(NettyTileEntity::markRemoved);
         knownTileEntitiesByColumnBucket.clear();
-        transitions.clear();
+        transitions.clearPublishedTransitions();
     }
 
     private void removeTileEntitiesInChunk(int chunkX, int chunkZ) {

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/AbstractBlockView.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/AbstractBlockView.java
@@ -160,29 +160,27 @@ public abstract class AbstractBlockView<R extends Clearable, T extends NettyTile
     }
 
     @Override
-    public Collection<TrackedTileEntity<?>> applyTileEntityCheckMode(boolean enabled, int currentTick) {
+    public void applyTileEntityCheckMode(boolean enabled, int currentTick, Consumer<TrackedTileEntity<?>> visibilityRepairConsumer) {
         long current = tileEntityCheckModeTokenAcquire();
         if (modeEnabled(current) == enabled) {
-            return null;
+            return;
         }
         // Drop the enabled bit, increment the generation, then restore bit 0 below only for enabled mode.
         long next = ((current >>> 1) + 1L) << 1;
         if (enabled) {
             forEachTileEntity(tileEntity -> tileEntity.setLastChecked(TrackedTileEntity.NEVER_CHECKED));
             TILE_ENTITY_CHECK_MODE_TOKEN.setRelease(this, next | 1L);
-            return null;
+            return;
         }
 
         TILE_ENTITY_CHECK_MODE_TOKEN.setRelease(this, next);
-        ArrayList<TrackedTileEntity<?>> visibilityRepairs = new ArrayList<>();
         forEachTileEntity(tileEntity -> {
             if (!tileEntity.visible()) {
                 tileEntity.setVisible(true);
                 tileEntity.setLastChecked(currentTick);
-                visibilityRepairs.add(tileEntity);
+                visibilityRepairConsumer.accept(tileEntity);
             }
         });
-        return visibilityRepairs;
     }
 
     @Override

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/BlockView.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/BlockView.java
@@ -6,9 +6,9 @@ import games.cubi.raycastedantiesp.core.tracked.TrackedTileEntity;
 import games.cubi.raycastedantiesp.core.chunks.BlockChunkData;
 import games.cubi.raycastedantiesp.core.chunks.OccludingChunkData;
 import games.cubi.raycastedantiesp.core.utils.Clearable;
+import org.jetbrains.annotations.Nullable;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.IntSupplier;
@@ -40,9 +40,6 @@ public interface BlockView extends Clearable {
 
     boolean isVisible(UUID world, BlockSpatial position, int currentTick);
 
-    /** Applies a checked visibility decision and queues any required client transition. */
-    void applyTileEntityVisibilityDecision(TrackedTileEntity<?> tileEntity, boolean visible, int currentTick, long modeToken, int expectedWorldEpoch);
-
     /**
      * Records visibility established by the current outbound packet without queuing another packet. This also resets
      * the check timestamp because the transmitted state supersedes the result of any previous visibility check. The
@@ -50,8 +47,13 @@ public interface BlockView extends Clearable {
      */
     void recordOutboundTileEntityVisibility(TrackedTileEntity<?> tileEntity, boolean visible);
 
-    /** Applies a mode change from the structural writer. */
-    void applyTileEntityCheckMode(boolean enabled, int currentTick);
+    /**
+     * Applies a mode change from the structural writer.
+     *
+     * @return tile entities made visible when checks were disabled; the structural writer must send their current state
+     * directly rather than publishing them to the engine transition queue.
+     */
+    @Nullable Collection<TrackedTileEntity<?>> applyTileEntityCheckMode(boolean enabled, int currentTick);
 
     /** Returns an opaque enabled-state/generation snapshot for rejecting results that cross a mode change. */
     long tileEntityCheckModeToken();
@@ -86,7 +88,15 @@ public interface BlockView extends Clearable {
 
     boolean hasPendingTransitions();
 
-    List<BlockViewTransition> drainTransitions();
+    /** Publishes the partial transition batch owned by the current engine producer. */
+    void flushPendingTransitions();
+
+    @FunctionalInterface
+    interface TransitionConsumer {
+        void accept(BlockViewTransition.Type type, TrackedTileEntity<?> tileEntity, long modeToken, int worldEpoch);
+    }
+
+    void drainTransitions(TransitionConsumer consumer);
 
     /** Structural-writer operation. */
     void upsertBlock(UUID world, int x, int y, int z, int blockID);

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/BlockView.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/BlockView.java
@@ -6,8 +6,6 @@ import games.cubi.raycastedantiesp.core.tracked.TrackedTileEntity;
 import games.cubi.raycastedantiesp.core.chunks.BlockChunkData;
 import games.cubi.raycastedantiesp.core.chunks.OccludingChunkData;
 import games.cubi.raycastedantiesp.core.utils.Clearable;
-import org.jetbrains.annotations.Nullable;
-
 import java.util.Collection;
 import java.util.UUID;
 import java.util.function.Consumer;
@@ -50,10 +48,11 @@ public interface BlockView extends Clearable {
     /**
      * Applies a mode change from the structural writer.
      *
-     * @return tile entities made visible when checks were disabled; the structural writer must send their current state
-     * directly rather than publishing them to the engine transition queue.
+     * Invokes {@code visibilityRepairConsumer} for each tile entity made visible when checks are disabled. The
+     * structural writer must send their current state directly rather than publishing them to the engine transition
+     * queue.
      */
-    @Nullable Collection<TrackedTileEntity<?>> applyTileEntityCheckMode(boolean enabled, int currentTick);
+    void applyTileEntityCheckMode(boolean enabled, int currentTick, Consumer<TrackedTileEntity<?>> visibilityRepairConsumer);
 
     /** Returns an opaque enabled-state/generation snapshot for rejecting results that cross a mode change. */
     long tileEntityCheckModeToken();

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/EntityView.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/EntityView.java
@@ -47,6 +47,13 @@ public interface EntityView<T extends TrackedEntity<?>>  extends Clearable {
 
     void setVisibility(NettyEntity<?> entity, boolean visible, int currentTick, int expectedWorldEpoch);
 
+    /**
+     * Applies visibility from the Netty structural writer without publishing an engine transition.
+     *
+     * @return whether the entity and epoch were current and the visibility was applied
+     */
+    boolean recordDirectVisibility(NettyEntity<?> entity, boolean visible, int currentTick, int expectedWorldEpoch);
+
     Collection<UUID> getKnownEntities();
 
     int[] getKnownEntityIDs();

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/EntityView.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/EntityView.java
@@ -6,7 +6,6 @@ import games.cubi.raycastedantiesp.core.tracked.NettyEntity;
 import games.cubi.raycastedantiesp.core.utils.Clearable;
 
 import java.util.Collection;
-import java.util.List;
 import java.util.UUID;
 import java.util.function.Consumer;
 import java.util.function.IntSupplier;
@@ -74,7 +73,15 @@ public interface EntityView<T extends TrackedEntity<?>>  extends Clearable {
 
     boolean hasPendingTransitions();
 
-    List<EntityViewTransition> drainTransitions();
+    /** Publishes the partial transition batch owned by the current engine producer. */
+    void flushPendingTransitions();
+
+    @FunctionalInterface
+    interface TransitionConsumer {
+        void accept(EntityViewTransition.Type type, TrackedEntity<?> entity, int worldEpoch);
+    }
+
+    void drainTransitions(TransitionConsumer consumer);
 
     boolean isPlayerView();
 

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/PackedBlockTransitionQueue.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/PackedBlockTransitionQueue.java
@@ -1,0 +1,190 @@
+package games.cubi.raycastedantiesp.core.view;
+
+import games.cubi.raycastedantiesp.core.utils.Clearable;
+import games.cubi.utils.IntrusiveSPSCQueue;
+import games.cubi.raycastedantiesp.core.tracked.TrackedTileEntity;
+
+import java.util.Objects;
+
+/**
+ * Queues tile-entity visibility transitions without allocating a record for every transition.
+ *
+ * <p>Exactly one engine thread at a time owns the pending batch and publishes it to the intrusive SPSC queue. The
+ * producer role may migrate between engine threads, while the player's Netty thread exclusively drains published
+ * entries. Producer and consumer methods must not be called from the opposite role.</p>
+ */
+public final class PackedBlockTransitionQueue {
+    private static final int BATCH_MIN_SIZE = 3;
+    private static final int BATCH_SIZE = 8;
+
+    private final IntrusiveSPSCQueue<QueueEntry> publishedEntries = new IntrusiveSPSCQueue<>();
+    private final PendingBatch pending = new PendingBatch();
+
+    public void add(BlockViewTransition.Type type, TrackedTileEntity<?> tileEntity, long modeToken, int worldEpoch) {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(tileEntity, "tileEntity");
+
+        if (pending.count != 0 && (pending.modeToken != modeToken || pending.worldEpoch != worldEpoch)) {
+            flushPending();
+        }
+        if (pending.count == 0) {
+            pending.modeToken = modeToken;
+            pending.worldEpoch = worldEpoch;
+        }
+        pending.add(type, tileEntity);
+        if (pending.count == BATCH_SIZE) {
+            flushPending();
+        }
+    }
+
+    /** Publishes the producer-owned partial batch. Only the engine producer may call this method. */
+    public void flushPendingTransitions() {
+        flushPending();
+    }
+
+    public boolean hasPendingTransitions() {
+        return !publishedEntries.isEmpty();
+    }
+
+    /**
+     * Drains published entries in FIFO order. A claimed queue entry is consumed at most once if a callback throws while
+     * processing it, and any unvisited transitions packed into that entry are discarded.
+     */
+    public void drainTransitions(BlockView.TransitionConsumer consumer) {
+        Objects.requireNonNull(consumer, "consumer");
+        QueueEntry entry;
+        while ((entry = publishedEntries.poll()) != null) {
+            entry.drain(consumer);
+        }
+    }
+
+    public void clear() {
+        publishedEntries.clear();
+        pending.clear();
+    }
+
+    private void flushPending() {
+        switch (pending.count) {
+            case 0 -> {
+                return;
+            }
+            case 1 -> publishedEntries.offer(new SingleEntry(pending.t1, pending.e1, pending.modeToken, pending.worldEpoch));
+            case 2 -> {
+                publishedEntries.offer(new SingleEntry(pending.t1, pending.e1, pending.modeToken, pending.worldEpoch));
+                publishedEntries.offer(new SingleEntry(pending.t2, pending.e2, pending.modeToken, pending.worldEpoch));
+            }
+            case BATCH_MIN_SIZE, 4, 5, 6, 7, BATCH_SIZE -> publishedEntries.offer(new BatchEntry(pending));
+            default -> throw new IllegalStateException("Tile transition batch exceeded eight entries");
+        }
+        pending.clear();
+    }
+
+    private abstract static class QueueEntry extends IntrusiveSPSCQueue.Node {
+        abstract void drain(BlockView.TransitionConsumer consumer);
+    }
+
+    private static final class SingleEntry extends QueueEntry {
+        private final BlockViewTransition.Type type;
+        private final TrackedTileEntity<?> tileEntity;
+        private final long modeToken;
+        private final int worldEpoch;
+
+        private SingleEntry(BlockViewTransition.Type type, TrackedTileEntity<?> tileEntity, long modeToken, int worldEpoch) {
+            this.type = type;
+            this.tileEntity = tileEntity;
+            this.modeToken = modeToken;
+            this.worldEpoch = worldEpoch;
+        }
+
+        @Override
+        public void drain(BlockView.TransitionConsumer consumer) {
+            consumer.accept(type, tileEntity, modeToken, worldEpoch);
+        }
+    }
+
+    private static final class PendingBatch implements Clearable {
+        private BlockViewTransition.Type t1, t2, t3, t4, t5, t6, t7, t8;
+        private TrackedTileEntity<?> e1, e2, e3, e4, e5, e6, e7, e8;
+        private long modeToken;
+        private int worldEpoch;
+        private int count;
+
+        private void add(BlockViewTransition.Type type, TrackedTileEntity<?> tileEntity) {
+            switch (++count) {
+                case 1 -> { t1 = type; e1 = tileEntity; }
+                case 2 -> { t2 = type; e2 = tileEntity; }
+                case 3 -> { t3 = type; e3 = tileEntity; }
+                case 4 -> { t4 = type; e4 = tileEntity; }
+                case 5 -> { t5 = type; e5 = tileEntity; }
+                case 6 -> { t6 = type; e6 = tileEntity; }
+                case 7 -> { t7 = type; e7 = tileEntity; }
+                case 8 -> { t8 = type; e8 = tileEntity; }
+                default -> throw new IllegalStateException("Tile transition batch exceeded eight entries");
+            }
+        }
+
+        public void clear() {
+            t1 = null;
+            t2 = null;
+            t3 = null;
+            t4 = null;
+            t5 = null;
+            t6 = null;
+            t7 = null;
+            t8 = null;
+            e1 = null;
+            e2 = null;
+            e3 = null;
+            e4 = null;
+            e5 = null;
+            e6 = null;
+            e7 = null;
+            e8 = null;
+            modeToken = 0L;
+            worldEpoch = 0;
+            count = 0;
+        }
+    }
+
+    private static final class BatchEntry extends QueueEntry {
+        private final BlockViewTransition.Type t1, t2, t3, t4, t5, t6, t7, t8;
+        private final TrackedTileEntity<?> e1, e2, e3, e4, e5, e6, e7, e8;
+        private final long modeToken;
+        private final int worldEpoch;
+        private final int count;
+
+        private BatchEntry(PendingBatch pending) {
+            t1 = pending.t1;
+            t2 = pending.t2;
+            t3 = pending.t3;
+            t4 = pending.t4;
+            t5 = pending.t5;
+            t6 = pending.t6;
+            t7 = pending.t7;
+            t8 = pending.t8;
+            e1 = pending.e1;
+            e2 = pending.e2;
+            e3 = pending.e3;
+            e4 = pending.e4;
+            e5 = pending.e5;
+            e6 = pending.e6;
+            e7 = pending.e7;
+            e8 = pending.e8;
+            modeToken = pending.modeToken;
+            worldEpoch = pending.worldEpoch;
+            count = pending.count;
+        }
+
+        @Override
+        public void drain(BlockView.TransitionConsumer consumer) {
+            consumer.accept(t1, e1, modeToken, worldEpoch);
+            if (count >= 2) consumer.accept(t2, e2, modeToken, worldEpoch);
+            if (count >= 3) consumer.accept(t3, e3, modeToken, worldEpoch);
+            if (count >= 4) consumer.accept(t4, e4, modeToken, worldEpoch);
+            if (count >= 5) consumer.accept(t5, e5, modeToken, worldEpoch);
+            if (count >= 6) consumer.accept(t6, e6, modeToken, worldEpoch);
+            if (count >= 7) consumer.accept(t7, e7, modeToken, worldEpoch);
+            if (count >= 8) consumer.accept(t8, e8, modeToken, worldEpoch);
+        }
+    }
+}

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/PackedBlockTransitionQueue.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/PackedBlockTransitionQueue.java
@@ -58,9 +58,13 @@ public final class PackedBlockTransitionQueue {
         }
     }
 
-    public void clear() {
+    /**
+     * Discards transitions already published to the consumer. The producer-owned pending batch is intentionally left
+     * untouched: a structural clear can race an engine flush, and that in-flight batch must retain its old epoch and
+     * mode token so the consumer can reject it normally after it is published.
+     */
+    public void clearPublishedTransitions() {
         publishedEntries.clear();
-        pending.clear();
     }
 
     private void flushPending() {

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/PackedEntityTransitionQueue.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/PackedEntityTransitionQueue.java
@@ -57,9 +57,13 @@ public final class PackedEntityTransitionQueue { //todo: potentially merge this 
         }
     }
 
-    public void clear() {
+    /**
+     * Discards transitions already published to the consumer. The producer-owned pending batch is intentionally left
+     * untouched: a structural clear can race an engine flush, and that in-flight batch must retain its old epoch so
+     * the consumer can reject it normally after it is published.
+     */
+    public void clearPublishedTransitions() {
         publishedEntries.clear();
-        pending.clear();
     }
 
     private void flushPending() {

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/PackedEntityTransitionQueue.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/PackedEntityTransitionQueue.java
@@ -1,0 +1,211 @@
+package games.cubi.raycastedantiesp.core.view;
+
+import games.cubi.raycastedantiesp.core.utils.Clearable;
+import games.cubi.utils.IntrusiveSPSCQueue;
+import games.cubi.raycastedantiesp.core.tracked.TrackedEntity;
+
+import java.util.Objects;
+
+/**
+ * Queues entity visibility transitions without allocating a record for every transition.
+ *
+ * <p>Exactly one engine thread at a time owns the pending batch and publishes it to the intrusive SPSC queue. The
+ * producer role may migrate between engine threads, while the player's Netty thread exclusively drains published
+ * entries. Producer and consumer methods must not be called from the opposite role.</p>
+ */
+public final class PackedEntityTransitionQueue { //todo: potentially merge this with PackedBlockTransitionQueue, and add a mode token to entities
+    private static final int BATCH_MIN_SIZE = 3;
+    private static final int BATCH_SIZE = 8;
+
+    private final IntrusiveSPSCQueue<QueueEntry> publishedEntries = new IntrusiveSPSCQueue<>();
+    private final PendingBatch pending = new PendingBatch();
+
+    public void add(EntityViewTransition.Type type, TrackedEntity<?> entity, int worldEpoch) {
+        Objects.requireNonNull(type, "type");
+        Objects.requireNonNull(entity, "entity");
+
+        if (pending.count != 0 && pending.worldEpoch != worldEpoch) {
+            flushPending();
+        }
+        if (pending.count == 0) {
+            pending.worldEpoch = worldEpoch;
+        }
+        pending.add(type, entity);
+        if (pending.count == BATCH_SIZE) {
+            flushPending();
+        }
+    }
+
+    /** Publishes the producer-owned partial batch. Only the engine producer may call this method. */
+    public void flushPendingTransitions() {
+        flushPending();
+    }
+
+    public boolean hasPendingTransitions() {
+        return !publishedEntries.isEmpty();
+    }
+
+    /**
+     * Drains published entries in FIFO order. A claimed queue entry is consumed at most once if a callback throws while
+     * processing it, and any unvisited transitions packed into that entry are discarded.
+     */
+    public void drainTransitions(EntityView.TransitionConsumer consumer) {
+        Objects.requireNonNull(consumer, "consumer");
+        QueueEntry entry;
+        while ((entry = publishedEntries.poll()) != null) {
+            entry.drain(consumer);
+        }
+    }
+
+    public void clear() {
+        publishedEntries.clear();
+        pending.clear();
+    }
+
+    private void flushPending() {
+        switch (pending.count) {
+            case 0 -> {
+                return;
+            }
+            case 1 -> publishedEntries.offer(new SingleEntry(pending.t1, pending.e1, pending.worldEpoch));
+            case 2 -> {
+                publishedEntries.offer(new SingleEntry(pending.t1, pending.e1, pending.worldEpoch));
+                publishedEntries.offer(new SingleEntry(pending.t2, pending.e2, pending.worldEpoch));
+            }
+            case BATCH_MIN_SIZE, 4, 5, 6, 7, BATCH_SIZE -> publishedEntries.offer(new BatchEntry(pending));
+            default -> throw new IllegalStateException("Entity transition batch exceeded eight entries");
+        }
+        pending.clear();
+    }
+
+    private abstract static class QueueEntry extends IntrusiveSPSCQueue.Node {
+        abstract void drain(EntityView.TransitionConsumer consumer);
+    }
+
+    private static final class SingleEntry extends QueueEntry {
+        private final EntityViewTransition.Type type;
+        private final TrackedEntity<?> entity;
+        private final int worldEpoch;
+
+        private SingleEntry(EntityViewTransition.Type type, TrackedEntity<?> entity, int worldEpoch) {
+            this.type = type;
+            this.entity = entity;
+            this.worldEpoch = worldEpoch;
+        }
+
+        @Override
+        public void drain(EntityView.TransitionConsumer consumer) {
+            consumer.accept(type, entity, worldEpoch);
+        }
+    }
+
+    private static final class PendingBatch implements Clearable {
+        private EntityViewTransition.Type t1;
+        private EntityViewTransition.Type t2;
+        private EntityViewTransition.Type t3;
+        private EntityViewTransition.Type t4;
+        private EntityViewTransition.Type t5;
+        private EntityViewTransition.Type t6;
+        private EntityViewTransition.Type t7;
+        private EntityViewTransition.Type t8;
+        private TrackedEntity<?> e1;
+        private TrackedEntity<?> e2;
+        private TrackedEntity<?> e3;
+        private TrackedEntity<?> e4;
+        private TrackedEntity<?> e5;
+        private TrackedEntity<?> e6;
+        private TrackedEntity<?> e7;
+        private TrackedEntity<?> e8;
+        private int worldEpoch;
+        private int count;
+
+        private void add(EntityViewTransition.Type type, TrackedEntity<?> entity) {
+            switch (++count) {
+                case 1 -> { t1 = type; e1 = entity; }
+                case 2 -> { t2 = type; e2 = entity; }
+                case 3 -> { t3 = type; e3 = entity; }
+                case 4 -> { t4 = type; e4 = entity; }
+                case 5 -> { t5 = type; e5 = entity; }
+                case 6 -> { t6 = type; e6 = entity; }
+                case 7 -> { t7 = type; e7 = entity; }
+                case 8 -> { t8 = type; e8 = entity; }
+                default -> throw new IllegalStateException("Entity transition batch exceeded eight entries");
+            }
+        }
+
+        public void clear() {
+            t1 = null;
+            t2 = null;
+            t3 = null;
+            t4 = null;
+            t5 = null;
+            t6 = null;
+            t7 = null;
+            t8 = null;
+            e1 = null;
+            e2 = null;
+            e3 = null;
+            e4 = null;
+            e5 = null;
+            e6 = null;
+            e7 = null;
+            e8 = null;
+            worldEpoch = 0;
+            count = 0;
+        }
+    }
+
+    private static final class BatchEntry extends QueueEntry {
+        private final EntityViewTransition.Type t1;
+        private final EntityViewTransition.Type t2;
+        private final EntityViewTransition.Type t3;
+        private final EntityViewTransition.Type t4;
+        private final EntityViewTransition.Type t5;
+        private final EntityViewTransition.Type t6;
+        private final EntityViewTransition.Type t7;
+        private final EntityViewTransition.Type t8;
+        private final TrackedEntity<?> e1;
+        private final TrackedEntity<?> e2;
+        private final TrackedEntity<?> e3;
+        private final TrackedEntity<?> e4;
+        private final TrackedEntity<?> e5;
+        private final TrackedEntity<?> e6;
+        private final TrackedEntity<?> e7;
+        private final TrackedEntity<?> e8;
+        private final int worldEpoch;
+        private final int count;
+
+        private BatchEntry(PendingBatch pending) {
+            t1 = pending.t1;
+            t2 = pending.t2;
+            t3 = pending.t3;
+            t4 = pending.t4;
+            t5 = pending.t5;
+            t6 = pending.t6;
+            t7 = pending.t7;
+            t8 = pending.t8;
+            e1 = pending.e1;
+            e2 = pending.e2;
+            e3 = pending.e3;
+            e4 = pending.e4;
+            e5 = pending.e5;
+            e6 = pending.e6;
+            e7 = pending.e7;
+            e8 = pending.e8;
+            worldEpoch = pending.worldEpoch;
+            count = pending.count;
+        }
+
+        @Override
+        public void drain(EntityView.TransitionConsumer consumer) {
+            consumer.accept(t1, e1, worldEpoch);
+            if (count >= 2) consumer.accept(t2, e2, worldEpoch);
+            if (count >= 3) consumer.accept(t3, e3, worldEpoch);
+            if (count >= 4) consumer.accept(t4, e4, worldEpoch);
+            if (count >= 5) consumer.accept(t5, e5, worldEpoch);
+            if (count >= 6) consumer.accept(t6, e6, worldEpoch);
+            if (count >= 7) consumer.accept(t7, e7, worldEpoch);
+            if (count >= 8) consumer.accept(t8, e8, worldEpoch);
+        }
+    }
+}

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/controller/PacketEntityViewController.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/controller/PacketEntityViewController.java
@@ -96,6 +96,9 @@ public abstract class PacketEntityViewController<P> {
 
     protected abstract NettyEntity<?> createSelfEntity(PlayerData ownData, int entityID, UUID playerUUID);
 
+    /** Applies a SHOW transition immediately on the Netty thread without publishing it to the engine SPSC queue. */
+    protected abstract void processDirectEntityShow(PlayerData playerData, EntityView<?> view, NettyEntity<?> entity, int worldEpoch);
+
     protected void handlePlayerDisconnect(UUID player) {
         if (player == null) {
             return;

--- a/core/src/main/java/games/cubi/raycastedantiesp/core/view/controller/PacketEntityViewController.java
+++ b/core/src/main/java/games/cubi/raycastedantiesp/core/view/controller/PacketEntityViewController.java
@@ -308,6 +308,9 @@ public abstract class PacketEntityViewController<P> {
                 }
                 else if (entity.isSelfEntity() && forceVisibleBecauseAttached(passenger, playerData, currentTick, "self-vehicle passenger")) {
                     passengersNotVisible = true;
+                    // The direct SHOW path already makes this passenger client-visible. Keep it in the
+                    // replacement relationship packet so the packet does not undo the newly established mount.
+                    visiblePassengers.add(passengerID);
                 }
                 else if (entity.isSelfEntity() || passenger.isSelfEntity()) {
                     visiblePassengers.add(passengerID);
@@ -546,7 +549,14 @@ public abstract class PacketEntityViewController<P> {
             // Note that this path can fire when a vehicle is bypassed, so its log level must be higher than default.
             return false;
         }
-        view.setVisibility(entity, true, currentTick, self.acquireWorldEpoch());
+        boolean wasVisible = entity.visible();
+        int worldEpoch = self.acquireWorldEpoch();
+        if (!view.recordDirectVisibility(entity, true, currentTick, worldEpoch)) {
+            return false;
+        }
+        if (!wasVisible || !wasClientVisible) {
+            processDirectEntityShow(self, view, entity, worldEpoch);
+        }
         return !wasClientVisible;
     }
 

--- a/core/src/test/java/games/cubi/raycastedantiesp/core/view/PackedTransitionQueueTest.java
+++ b/core/src/test/java/games/cubi/raycastedantiesp/core/view/PackedTransitionQueueTest.java
@@ -113,7 +113,7 @@ class PackedTransitionQueueTest {
         PackedEntityTransitionQueue entityQueue = new PackedEntityTransitionQueue();
         entityQueue.add(EntityViewTransition.Type.SHOW, entity(), 1);
         entityQueue.flushPendingTransitions();
-        entityQueue.clear();
+        entityQueue.clearPublishedTransitions();
         assertFalse(entityQueue.hasPendingTransitions());
         entityQueue.drainTransitions((type, entity, worldEpoch) -> {
             throw new AssertionError("cleared entity transition was drained");
@@ -122,17 +122,59 @@ class PackedTransitionQueueTest {
         for (int index = 0; index < 8; index++) {
             entityQueue.add(EntityViewTransition.Type.SHOW, entity(), 1);
         }
-        entityQueue.clear();
+        entityQueue.clearPublishedTransitions();
         assertFalse(entityQueue.hasPendingTransitions());
 
         PackedBlockTransitionQueue blockQueue = new PackedBlockTransitionQueue();
         blockQueue.add(BlockViewTransition.Type.HIDE, tileEntity(), 1L, 1);
         blockQueue.flushPendingTransitions();
-        blockQueue.clear();
+        blockQueue.clearPublishedTransitions();
         assertFalse(blockQueue.hasPendingTransitions());
         blockQueue.drainTransitions((type, tileEntity, modeToken, worldEpoch) -> {
             throw new AssertionError("cleared block transition was drained");
         });
+    }
+
+    @Test
+    void entityConsumerClearPreservesPendingBatchMetadata() {
+        PackedEntityTransitionQueue queue = new PackedEntityTransitionQueue();
+        TrackedEntity<?> published = entity();
+        TrackedEntity<?> pending = entity();
+        queue.add(EntityViewTransition.Type.SHOW, published, 3);
+        queue.flushPendingTransitions();
+        queue.add(EntityViewTransition.Type.HIDE, pending, 17);
+
+        queue.clearPublishedTransitions();
+        assertFalse(queue.hasPendingTransitions());
+
+        queue.flushPendingTransitions();
+        List<EntityObservation> observed = new ArrayList<>();
+        queue.drainTransitions((type, entity, worldEpoch) -> observed.add(new EntityObservation(type, entity, worldEpoch)));
+
+        assertEquals(List.of(pending), observed.stream().map(EntityObservation::entity).toList());
+        assertEquals(List.of(17), observed.stream().map(EntityObservation::worldEpoch).toList());
+    }
+
+    @Test
+    void blockConsumerClearPreservesPendingBatchMetadata() {
+        PackedBlockTransitionQueue queue = new PackedBlockTransitionQueue();
+        TrackedTileEntity<?> published = tileEntity();
+        TrackedTileEntity<?> pending = tileEntity();
+        queue.add(BlockViewTransition.Type.SHOW, published, 2L, 3);
+        queue.flushPendingTransitions();
+        queue.add(BlockViewTransition.Type.HIDE, pending, 19L, 23);
+
+        queue.clearPublishedTransitions();
+        assertFalse(queue.hasPendingTransitions());
+
+        queue.flushPendingTransitions();
+        List<BlockObservation> observed = new ArrayList<>();
+        queue.drainTransitions((type, tileEntity, modeToken, worldEpoch) ->
+                observed.add(new BlockObservation(type, tileEntity, modeToken, worldEpoch)));
+
+        assertEquals(List.of(pending), observed.stream().map(BlockObservation::tileEntity).toList());
+        assertEquals(List.of(19L), observed.stream().map(BlockObservation::modeToken).toList());
+        assertEquals(List.of(23), observed.stream().map(BlockObservation::worldEpoch).toList());
     }
 
     @Test

--- a/core/src/test/java/games/cubi/raycastedantiesp/core/view/PackedTransitionQueueTest.java
+++ b/core/src/test/java/games/cubi/raycastedantiesp/core/view/PackedTransitionQueueTest.java
@@ -1,0 +1,245 @@
+package games.cubi.raycastedantiesp.core.view;
+
+import games.cubi.raycastedantiesp.core.tracked.TrackedEntity;
+import games.cubi.raycastedantiesp.core.tracked.TrackedTileEntity;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertThrows;
+import static org.junit.jupiter.api.Assertions.assertFalse;
+import static org.junit.jupiter.api.Assertions.assertSame;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PackedTransitionQueueTest {
+    @Test
+    void entitySequencesPreserveOrderIdentityAndEpoch() {
+        for (int count : new int[]{1, 2, 3, 8, 9}) {
+            PackedEntityTransitionQueue queue = new PackedEntityTransitionQueue();
+            List<TrackedEntity<?>> entities = new ArrayList<>(count);
+            for (int index = 0; index < count; index++) {
+                TrackedEntity<?> entity = entity();
+                entities.add(entity);
+                queue.add(index % 2 == 0 ? EntityViewTransition.Type.SHOW : EntityViewTransition.Type.HIDE, entity, 7);
+            }
+
+            queue.flushPendingTransitions();
+            assertTrue(queue.hasPendingTransitions());
+            List<EntityObservation> observed = new ArrayList<>();
+            queue.drainTransitions((type, entity, worldEpoch) -> observed.add(new EntityObservation(type, entity, worldEpoch)));
+
+            assertEquals(count, observed.size());
+            for (int index = 0; index < count; index++) {
+                EntityObservation observation = observed.get(index);
+                assertSame(entities.get(index), observation.entity());
+                assertEquals(index % 2 == 0 ? EntityViewTransition.Type.SHOW : EntityViewTransition.Type.HIDE, observation.type());
+                assertEquals(7, observation.worldEpoch());
+            }
+            assertFalse(queue.hasPendingTransitions());
+        }
+    }
+
+    @Test
+    void entityMetadataChangeSplitsPendingBatch() {
+        PackedEntityTransitionQueue queue = new PackedEntityTransitionQueue();
+        TrackedEntity<?> first = entity();
+        TrackedEntity<?> second = entity();
+        TrackedEntity<?> third = entity();
+        queue.add(EntityViewTransition.Type.HIDE, first, 2);
+        queue.add(EntityViewTransition.Type.SHOW, second, 2);
+        queue.add(EntityViewTransition.Type.HIDE, third, 4);
+        queue.flushPendingTransitions();
+
+        List<EntityObservation> observed = new ArrayList<>();
+        queue.drainTransitions((type, entity, worldEpoch) -> observed.add(new EntityObservation(type, entity, worldEpoch)));
+
+        assertEquals(List.of(2, 2, 4), observed.stream().map(EntityObservation::worldEpoch).toList());
+        assertSame(first, observed.get(0).entity());
+        assertSame(second, observed.get(1).entity());
+        assertSame(third, observed.get(2).entity());
+    }
+
+    @Test
+    void blockSequencesPreserveOrderIdentityAndSharedMetadata() {
+        PackedBlockTransitionQueue queue = new PackedBlockTransitionQueue();
+        List<TrackedTileEntity<?>> tiles = new ArrayList<>();
+        for (int index = 0; index < 9; index++) {
+            TrackedTileEntity<?> tileEntity = tileEntity();
+            tiles.add(tileEntity);
+            queue.add(index % 2 == 0 ? BlockViewTransition.Type.SHOW : BlockViewTransition.Type.HIDE, tileEntity, 13L, 5);
+        }
+
+        queue.flushPendingTransitions();
+        List<BlockObservation> observed = new ArrayList<>();
+        queue.drainTransitions((type, tileEntity, modeToken, worldEpoch) ->
+                observed.add(new BlockObservation(type, tileEntity, modeToken, worldEpoch)));
+
+        assertEquals(9, observed.size());
+        for (int index = 0; index < observed.size(); index++) {
+            BlockObservation observation = observed.get(index);
+            assertSame(tiles.get(index), observation.tileEntity());
+            assertEquals(index % 2 == 0 ? BlockViewTransition.Type.SHOW : BlockViewTransition.Type.HIDE, observation.type());
+            assertEquals(13L, observation.modeToken());
+            assertEquals(5, observation.worldEpoch());
+        }
+    }
+
+    @Test
+    void blockMetadataChangeSplitsPendingBatch() {
+        PackedBlockTransitionQueue queue = new PackedBlockTransitionQueue();
+        TrackedTileEntity<?> first = tileEntity();
+        TrackedTileEntity<?> second = tileEntity();
+        TrackedTileEntity<?> third = tileEntity();
+        queue.add(BlockViewTransition.Type.HIDE, first, 3L, 2);
+        queue.add(BlockViewTransition.Type.SHOW, second, 3L, 2);
+        queue.add(BlockViewTransition.Type.SHOW, third, 5L, 2);
+        queue.flushPendingTransitions();
+
+        List<BlockObservation> observed = new ArrayList<>();
+        queue.drainTransitions((type, tileEntity, modeToken, worldEpoch) ->
+                observed.add(new BlockObservation(type, tileEntity, modeToken, worldEpoch)));
+
+        assertEquals(List.of(3L, 3L, 5L), observed.stream().map(BlockObservation::modeToken).toList());
+        assertEquals(List.of(2, 2, 2), observed.stream().map(BlockObservation::worldEpoch).toList());
+    }
+
+    @Test
+    void clearDiscardsPublishedEntries() {
+        PackedEntityTransitionQueue entityQueue = new PackedEntityTransitionQueue();
+        entityQueue.add(EntityViewTransition.Type.SHOW, entity(), 1);
+        entityQueue.flushPendingTransitions();
+        entityQueue.clear();
+        assertFalse(entityQueue.hasPendingTransitions());
+        entityQueue.drainTransitions((type, entity, worldEpoch) -> {
+            throw new AssertionError("cleared entity transition was drained");
+        });
+
+        for (int index = 0; index < 8; index++) {
+            entityQueue.add(EntityViewTransition.Type.SHOW, entity(), 1);
+        }
+        entityQueue.clear();
+        assertFalse(entityQueue.hasPendingTransitions());
+
+        PackedBlockTransitionQueue blockQueue = new PackedBlockTransitionQueue();
+        blockQueue.add(BlockViewTransition.Type.HIDE, tileEntity(), 1L, 1);
+        blockQueue.flushPendingTransitions();
+        blockQueue.clear();
+        assertFalse(blockQueue.hasPendingTransitions());
+        blockQueue.drainTransitions((type, tileEntity, modeToken, worldEpoch) -> {
+            throw new AssertionError("cleared block transition was drained");
+        });
+    }
+
+    @Test
+    void entityAppendDoesNotWaitForConsumerCallback() throws Exception {
+        PackedEntityTransitionQueue queue = new PackedEntityTransitionQueue();
+        queue.add(EntityViewTransition.Type.SHOW, entity(), 1);
+        queue.flushPendingTransitions();
+        CountDownLatch callbackStarted = new CountDownLatch(1);
+        CountDownLatch releaseCallback = new CountDownLatch(1);
+        CountDownLatch appendCompleted = new CountDownLatch(1);
+        CountDownLatch drainCompleted = new CountDownLatch(1);
+
+        Thread drainer = Thread.startVirtualThread(() -> {
+            queue.drainTransitions((type, queuedEntity, worldEpoch) -> {
+                callbackStarted.countDown();
+                try {
+                    releaseCallback.await(5, TimeUnit.SECONDS);
+                } catch (InterruptedException exception) {
+                    throw new AssertionError(exception);
+                }
+            });
+            drainCompleted.countDown();
+        });
+
+        assertTrue(callbackStarted.await(5, TimeUnit.SECONDS));
+        Thread producer = Thread.startVirtualThread(() -> {
+            queue.add(EntityViewTransition.Type.HIDE, entity(), 1);
+            queue.flushPendingTransitions();
+            appendCompleted.countDown();
+        });
+        assertTrue(appendCompleted.await(5, TimeUnit.SECONDS));
+        releaseCallback.countDown();
+        assertTrue(drainCompleted.await(5, TimeUnit.SECONDS));
+        producer.join();
+        drainer.join();
+    }
+
+    @Test
+    void callbackFailureHasAtMostOnceClaimedEntrySemantics() {
+        PackedEntityTransitionQueue queue = new PackedEntityTransitionQueue();
+        for (int index = 0; index < 3; index++) {
+            queue.add(EntityViewTransition.Type.SHOW, entity(), 1);
+        }
+        queue.flushPendingTransitions();
+
+        int[] callbacks = {0};
+        assertThrows(IllegalStateException.class, () -> queue.drainTransitions((type, entity, worldEpoch) -> {
+            callbacks[0]++;
+            throw new IllegalStateException("test callback failure");
+        }));
+        assertEquals(1, callbacks[0]);
+
+        queue.add(EntityViewTransition.Type.HIDE, entity(), 1);
+        queue.flushPendingTransitions();
+        assertTrue(queue.hasPendingTransitions());
+    }
+
+    @Test
+    void entityProducerCanMigrateBetweenThreads() throws Exception {
+        PackedEntityTransitionQueue queue = new PackedEntityTransitionQueue();
+        TrackedEntity<?> first = entity();
+        TrackedEntity<?> second = entity();
+
+        Thread firstProducer = Thread.startVirtualThread(() -> {
+            queue.add(EntityViewTransition.Type.SHOW, first, 1);
+            queue.flushPendingTransitions();
+        });
+        firstProducer.join();
+
+        Thread secondProducer = Thread.startVirtualThread(() -> {
+            queue.add(EntityViewTransition.Type.HIDE, second, 1);
+            queue.flushPendingTransitions();
+        });
+        secondProducer.join();
+
+        List<TrackedEntity<?>> observed = new ArrayList<>();
+        queue.drainTransitions((type, entity, worldEpoch) -> observed.add(entity));
+        assertEquals(List.of(first, second), observed);
+    }
+
+    private static TrackedEntity<?> entity() {
+        return proxy(TrackedEntity.class);
+    }
+
+    private static TrackedTileEntity<?> tileEntity() {
+        return proxy(TrackedTileEntity.class);
+    }
+
+    @SuppressWarnings("unchecked")
+    private static <T> T proxy(Class<T> type) {
+        return (T) Proxy.newProxyInstance(type.getClassLoader(), new Class<?>[]{type}, (object, method, args) -> {
+            if (method.getReturnType() == boolean.class) return false;
+            if (method.getReturnType() == byte.class) return (byte) 0;
+            if (method.getReturnType() == short.class) return (short) 0;
+            if (method.getReturnType() == int.class) return 0;
+            if (method.getReturnType() == long.class) return 0L;
+            if (method.getReturnType() == float.class) return 0.0f;
+            if (method.getReturnType() == double.class) return 0.0d;
+            if (method.getReturnType() == char.class) return (char) 0;
+            return null;
+        });
+    }
+
+    private record EntityObservation(EntityViewTransition.Type type, TrackedEntity<?> entity, int worldEpoch) {
+    }
+
+    private record BlockObservation(BlockViewTransition.Type type, TrackedTileEntity<?> tileEntity, long modeToken,
+            int worldEpoch) {
+    }
+}

--- a/core/src/test/java/games/cubi/raycastedantiesp/core/view/chunks/ChunkSectionStoreTest.java
+++ b/core/src/test/java/games/cubi/raycastedantiesp/core/view/chunks/ChunkSectionStoreTest.java
@@ -20,7 +20,7 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.Collection;
+import java.util.ArrayList;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
@@ -127,7 +127,7 @@ class ChunkSectionStoreTest {
         UUID worldB = UUID.randomUUID();
         ImmutableBlockLocatable locationA = new ImmutableBlockLocatable(worldA, 1, 2, 3);
 
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         view.upsertBlock(worldA, 1, 2, 3, 1);
         view.updateOrInsertTileEntity(locationA, 99, true);
         view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), ignored -> BlockView.VisibilityResolver.HIDE);
@@ -269,17 +269,22 @@ class ChunkSectionStoreTest {
     }
 
     @Test
-    void disablingTileChecksReturnsVisibilityRepairs() {
+    void disablingTileChecksConsumesVisibilityRepairs() {
         TestBlockView view = new TestBlockView(ODD_OCCLUDING, false);
         UUID world = UUID.randomUUID();
         ImmutableBlockSpatialImpl position = new ImmutableBlockSpatialImpl(1, 64, 2);
-        view.applyTileEntityCheckMode(true, 0);
-        TestTileEntity tileEntity = view.updateOrInsertTileEntity(world, position, 99, false);
+        ArrayList<TrackedTileEntity<?>> visibilityRepairs = new ArrayList<>();
 
-        Collection<TrackedTileEntity<?>> visibilityRepairs = view.applyTileEntityCheckMode(false, 1);
+        view.applyTileEntityCheckMode(true, 0, visibilityRepairs::add);
+        assertTrue(visibilityRepairs.isEmpty());
+        TestTileEntity tileEntity = view.updateOrInsertTileEntity(world, position, 99, false);
+        view.applyTileEntityCheckMode(true, 1, visibilityRepairs::add);
+        assertTrue(visibilityRepairs.isEmpty());
+
+        view.applyTileEntityCheckMode(false, 1, visibilityRepairs::add);
 
         assertEquals(1, visibilityRepairs.size());
-        assertSame(tileEntity, visibilityRepairs.iterator().next());
+        assertSame(tileEntity, visibilityRepairs.getFirst());
         assertTrue(tileEntity.visible());
         assertFalse(view.hasPendingTransitions());
     }
@@ -289,19 +294,19 @@ class ChunkSectionStoreTest {
         TestBlockView view = new TestBlockView(ODD_OCCLUDING, false);
         UUID world = UUID.randomUUID();
         ImmutableBlockLocatable location = new ImmutableBlockLocatable(world, 1, 64, 2);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         view.updateOrInsertTileEntity(location, 99, true);
         long staleToken = view.tileEntityCheckModeToken();
 
         int processed = view.updateVisibilityForEachNeedingRecheck(-1, 1, staleToken, ignored -> {
-            view.applyTileEntityCheckMode(false, 1);
+            view.applyTileEntityCheckMode(false, 1, unused -> {});
             return BlockView.VisibilityResolver.HIDE;
         });
 
         assertEquals(1, processed);
         assertTrue(view.isVisible(location, 1));
 
-        view.applyTileEntityCheckMode(true, 2);
+        view.applyTileEntityCheckMode(true, 2, unused -> {});
         long enabledToken = view.tileEntityCheckModeToken();
         AtomicInteger checks = new AtomicInteger();
         view.updateVisibilityForEachNeedingRecheck(-1, 2, enabledToken, ignored -> {
@@ -318,7 +323,7 @@ class ChunkSectionStoreTest {
         UUID firstWorld = UUID.randomUUID();
         UUID secondWorld = UUID.randomUUID();
         ImmutableBlockSpatialImpl position = new ImmutableBlockSpatialImpl(1, 64, 2);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         TestTileEntity original = view.updateOrInsertTileEntity(firstWorld, position, 99, true);
         long modeToken = view.tileEntityCheckModeToken();
         int staleEpoch = worldEpoch.getAcquire();
@@ -344,7 +349,7 @@ class ChunkSectionStoreTest {
             TestBlockView view = new TestBlockView(ODD_OCCLUDING, false);
             UUID world = UUID.randomUUID();
             ImmutableBlockLocatable location = new ImmutableBlockLocatable(world, 1, 64, 2);
-            view.applyTileEntityCheckMode(true, 0);
+            view.applyTileEntityCheckMode(true, 0, unused -> {});
             TestTileEntity tileEntity = view.updateOrInsertTileEntity(location, 99, true);
             long modeToken = view.tileEntityCheckModeToken();
             AtomicInteger acknowledgedTick = new AtomicInteger();

--- a/core/src/test/java/games/cubi/raycastedantiesp/core/view/chunks/ChunkSectionStoreTest.java
+++ b/core/src/test/java/games/cubi/raycastedantiesp/core/view/chunks/ChunkSectionStoreTest.java
@@ -20,8 +20,10 @@ import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
+import java.util.Collection;
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -128,7 +130,8 @@ class ChunkSectionStoreTest {
         view.applyTileEntityCheckMode(true, 0);
         view.upsertBlock(worldA, 1, 2, 3, 1);
         view.updateOrInsertTileEntity(locationA, 99, true);
-        view.applyTileEntityVisibilityDecision(locationA, false, 1);
+        view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), ignored -> BlockView.VisibilityResolver.HIDE);
+        view.flushPendingTransitions();
 
         Assertions.assertTrue(view.isBlockOccluding(worldA, 1, 2, 3));
         Assertions.assertFalse(view.isBlockOccluding(worldB, 1, 2, 3));
@@ -266,6 +269,22 @@ class ChunkSectionStoreTest {
     }
 
     @Test
+    void disablingTileChecksReturnsVisibilityRepairs() {
+        TestBlockView view = new TestBlockView(ODD_OCCLUDING, false);
+        UUID world = UUID.randomUUID();
+        ImmutableBlockSpatialImpl position = new ImmutableBlockSpatialImpl(1, 64, 2);
+        view.applyTileEntityCheckMode(true, 0);
+        TestTileEntity tileEntity = view.updateOrInsertTileEntity(world, position, 99, false);
+
+        Collection<TrackedTileEntity<?>> visibilityRepairs = view.applyTileEntityCheckMode(false, 1);
+
+        assertEquals(1, visibilityRepairs.size());
+        assertSame(tileEntity, visibilityRepairs.iterator().next());
+        assertTrue(tileEntity.visible());
+        assertFalse(view.hasPendingTransitions());
+    }
+
+    @Test
     void modeGenerationRejectsInFlightHideAndForcesFirstEnabledCheck() {
         TestBlockView view = new TestBlockView(ODD_OCCLUDING, false);
         UUID world = UUID.randomUUID();
@@ -333,24 +352,31 @@ class ChunkSectionStoreTest {
 
             Thread producer = Thread.startVirtualThread(() -> {
                 for (int tick = 1; tick <= transitions; tick++) {
-                    view.applyTileEntityVisibilityDecision(tileEntity, (tick & 1) == 0, tick, modeToken, 2);
+                    byte visibility = (tick & 1) == 0 ? BlockView.VisibilityResolver.SHOW : BlockView.VisibilityResolver.HIDE;
+                    view.updateVisibilityForEachNeedingRecheck(0, tick, modeToken, ignored -> visibility);
+                    view.flushPendingTransitions();
                     while (acknowledgedTick.getAcquire() != tick) {
                         Thread.onSpinWait();
                     }
                 }
             });
 
+            AtomicReference<BlockViewTransition.Type> transitionType = new AtomicReference<>();
+            AtomicReference<TrackedTileEntity<?>> transitionTileEntity = new AtomicReference<>();
+            boolean[] drained = {false};
             for (int tick = 1; tick <= transitions; tick++) {
-                var drained = view.drainTransitions();
-                while (drained.isEmpty()) {
-                    Thread.onSpinWait();
-                    drained = view.drainTransitions();
-                }
+                do {
+                    drained[0] = false;
+                    view.drainTransitions((type, queuedTileEntity, modeTokenValue, worldEpoch) -> {
+                        transitionType.set(type);
+                        transitionTileEntity.set(queuedTileEntity);
+                        drained[0] = true;
+                    });
+                } while (!drained[0]);
 
-                assertEquals(1, drained.size());
                 boolean expectedVisible = (tick & 1) == 0;
-                assertEquals(expectedVisible ? BlockViewTransition.Type.SHOW : BlockViewTransition.Type.HIDE, drained.getFirst().type());
-                assertSame(tileEntity, drained.getFirst().tileEntity());
+                assertEquals(expectedVisible ? BlockViewTransition.Type.SHOW : BlockViewTransition.Type.HIDE, transitionType.get());
+                assertSame(tileEntity, transitionTileEntity.get());
                 assertEquals(expectedVisible, tileEntity.visible());
                 assertEquals(tick, tileEntity.lastChecked());
                 acknowledgedTick.setRelease(tick);
@@ -470,11 +496,6 @@ class ChunkSectionStoreTest {
 
         private boolean isBlockOccluding(UUID world, int x, int y, int z) {
             return isBlockOccluding(new ImmutableBlockLocatable(world, x, y, z));
-        }
-
-        private void applyTileEntityVisibilityDecision(BlockLocatable location, boolean visible, int currentTick) {
-            TestTileEntity tileEntity = getTrackedTileEntity(location);
-            applyTileEntityVisibilityDecision(tileEntity, visible, currentTick, tileEntityCheckModeToken(), worldEpochSupplier.getAsInt());
         }
 
         private int updateVisibilityForEachNeedingRecheck(int recheckTicks, int currentTick, long modeToken, BlockView.VisibilityResolver action) {

--- a/core/src/test/java/games/cubi/raycastedantiesp/core/view/controller/PacketEntityViewControllerTest.java
+++ b/core/src/test/java/games/cubi/raycastedantiesp/core/view/controller/PacketEntityViewControllerTest.java
@@ -1,0 +1,272 @@
+package games.cubi.raycastedantiesp.core.view.controller;
+
+import games.cubi.raycastedantiesp.core.players.PlayerData;
+import games.cubi.raycastedantiesp.core.players.PlayerRegistry;
+import games.cubi.raycastedantiesp.core.tracked.NettyEntity;
+import games.cubi.raycastedantiesp.core.tracked.TrackedEntity;
+import games.cubi.raycastedantiesp.core.utils.Clearable;
+import games.cubi.raycastedantiesp.core.view.BlockView;
+import games.cubi.raycastedantiesp.core.view.EntityView;
+import games.cubi.raycastedantiesp.core.view.ViewRegistry;
+import it.unimi.dsi.fastutil.ints.IntArrayList;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.Test;
+
+import java.lang.reflect.Proxy;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.UUID;
+
+import static org.junit.jupiter.api.Assertions.assertArrayEquals;
+import static org.junit.jupiter.api.Assertions.assertEquals;
+import static org.junit.jupiter.api.Assertions.assertTrue;
+
+class PacketEntityViewControllerTest {
+    private static final TestController CONTROLLER = new TestController();
+    private final List<UUID> registeredPlayers = new ArrayList<>();
+
+    @BeforeAll
+    static void initialiseViews() {
+        ViewRegistry.initialise(
+                ignored -> emptyBlockView(),
+                ignored -> entityView(false),
+                ignored -> entityView(true)
+        );
+    }
+
+    @AfterEach
+    void unregisterPlayers() {
+        for (UUID player : registeredPlayers) {
+            PlayerRegistry.getInstance().unregisterPlayer(player);
+        }
+        registeredPlayers.clear();
+    }
+
+    @Test
+    void directlyShownSelfVehiclePassengersRemainMountedInReplacementPacket() {
+        CONTROLLER.directlyShownEntityIDs.clear();
+        CONTROLLER.replacementPassengerPackets.clear();
+        UUID playerUUID = UUID.randomUUID();
+        registeredPlayers.add(playerUUID);
+        PlayerData playerData = PlayerRegistry.getInstance().registerAndGetPlayer(
+                playerUUID,
+                0,
+                1,
+                TestEntity::createSelf
+        );
+        UUID world = UUID.randomUUID();
+        playerData.beginWorldTransition();
+        playerData.completeWorldTransition(world);
+
+        TestEntity firstPassenger = new TestEntity(playerData, 2, UUID.randomUUID(), false);
+        TestEntity secondPassenger = new TestEntity(playerData, 3, UUID.randomUUID(), false);
+        @SuppressWarnings("unchecked")
+        EntityView<NettyEntity<?>> entityView = (EntityView<NettyEntity<?>>) (EntityView<?>) playerData.entityView();
+        for (TestEntity passenger : List.of(firstPassenger, secondPassenger)) {
+            passenger.setVisible(false);
+            passenger.setClientVisible(false);
+            entityView.insertEntity(world, passenger);
+        }
+
+        TestEntity self = (TestEntity) playerData.nettyData().getSelfEntity();
+        boolean cancelled = CONTROLLER.handleEntityPassengersNow(self, new int[]{2, 3}, playerData, 17);
+
+        assertTrue(cancelled, "the original passenger packet must be suppressed");
+        assertEquals(List.of(2, 3), CONTROLLER.directlyShownEntityIDs);
+        assertEquals(1, CONTROLLER.replacementPassengerPackets.size());
+        assertArrayEquals(new int[]{2, 3}, CONTROLLER.replacementPassengerPackets.get(0));
+        for (TestEntity passenger : List.of(firstPassenger, secondPassenger)) {
+            assertTrue(passenger.visible(), "direct SHOW must make the passenger engine-visible");
+            assertTrue(passenger.clientVisible(), "direct SHOW must make the passenger client-visible");
+            assertEquals(1, passenger.vehicleID(), "the passenger must remain attached to the self vehicle");
+        }
+        assertArrayEquals(new int[]{2, 3}, self.passengerIDs());
+    }
+
+    private static EntityView<?> entityView(boolean playerView) {
+        Map<Integer, TrackedEntity<?>> entitiesByID = new HashMap<>();
+        Map<UUID, TrackedEntity<?>> entitiesByUUID = new HashMap<>();
+        return (EntityView<?>) Proxy.newProxyInstance(
+                PacketEntityViewControllerTest.class.getClassLoader(),
+                new Class[]{EntityView.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "insertEntity" -> {
+                        TrackedEntity<?> entity = (TrackedEntity<?>) args[1];
+                        entitiesByID.put(entity.entityID(), entity);
+                        entitiesByUUID.put(entity.entityUUID(), entity);
+                        yield null;
+                    }
+                    case "removeEntity" -> {
+                        int entityID = (Integer) args[0];
+                        TrackedEntity<?> removed = entitiesByID.remove(entityID);
+                        if (removed != null) {
+                            entitiesByUUID.remove(removed.entityUUID());
+                        }
+                        yield null;
+                    }
+                    case "getEntity" -> args[0] instanceof Integer
+                            ? entitiesByID.get(args[0])
+                            : entitiesByUUID.get(args[0]);
+                    case "exists" -> args[0] instanceof Integer
+                            ? entitiesByID.containsKey(args[0])
+                            : entitiesByUUID.containsKey(args[0]);
+                    case "size" -> entitiesByID.size();
+                    case "getKnownEntities" -> List.copyOf(entitiesByUUID.keySet());
+                    case "getKnownEntityIDs" -> entitiesByID.keySet().stream().mapToInt(Integer::intValue).toArray();
+                    case "getEntityID" -> {
+                        TrackedEntity<?> entity = entitiesByUUID.get(args[0]);
+                        yield entity == null ? -1 : entity.entityID();
+                    }
+                    case "getPosition" -> entitiesByUUID.get(args[0]);
+                    case "isVisible" -> {
+                        TrackedEntity<?> entity = args[0] instanceof Integer
+                                ? entitiesByID.get(args[0])
+                                : entitiesByUUID.get(args[0]);
+                        yield entity == null || entity.visible();
+                    }
+                    case "recordDirectVisibility", "setVisibility" -> {
+                        NettyEntity<?> entity = (NettyEntity<?>) args[0];
+                        boolean current = entitiesByUUID.get(entity.entityUUID()) == entity && !entity.isSelfEntity();
+                        if (current) {
+                            entity.setVisible((Boolean) args[1]);
+                            entity.setLastChecked((Integer) args[2]);
+                        }
+                        yield method.getName().equals("recordDirectVisibility") ? current : null;
+                    }
+                    case "forEachNeedingRecheck", "forEachNeedingRecheckEntity" -> 0;
+                    case "hasPendingTransitions" -> false;
+                    case "flushPendingTransitions", "drainTransitions", "clear" -> null;
+                    case "isPlayerView" -> playerView;
+                    case "getStringDataForDebugging" -> "test";
+                    case "toString" -> "TestEntityView";
+                    default -> defaultValue(method.getReturnType());
+                }
+        );
+    }
+
+    private static BlockView emptyBlockView() {
+        return (BlockView) Proxy.newProxyInstance(
+                PacketEntityViewControllerTest.class.getClassLoader(),
+                new Class[]{BlockView.class},
+                (proxy, method, args) -> switch (method.getName()) {
+                    case "toString" -> "TestBlockView";
+                    default -> defaultValue(method.getReturnType());
+                }
+        );
+    }
+
+    private static Object defaultValue(Class<?> returnType) {
+        if (!returnType.isPrimitive()) {
+            return null;
+        }
+        if (returnType == boolean.class) {
+            return false;
+        }
+        if (returnType == long.class) {
+            return 0L;
+        }
+        if (returnType == float.class) {
+            return 0F;
+        }
+        if (returnType == double.class) {
+            return 0D;
+        }
+        if (returnType == byte.class) {
+            return (byte) 0;
+        }
+        if (returnType == short.class) {
+            return (short) 0;
+        }
+        if (returnType == char.class) {
+            return (char) 0;
+        }
+        return 0;
+    }
+
+    private static final class TestController extends PacketEntityViewController<Void> {
+        private final List<Integer> directlyShownEntityIDs = new ArrayList<>();
+        private final List<int[]> replacementPassengerPackets = new ArrayList<>();
+
+        @Override
+        protected NettyEntity<?> createSelfEntity(PlayerData ownData, int entityID, UUID playerUUID) {
+            return TestEntity.createSelf(ownData, entityID, playerUUID);
+        }
+
+        @Override
+        protected NettyEntity<?> processEntitySpawn(PlayerData playerData, Void packet, UUID world, int currentTick) {
+            return null;
+        }
+
+        @Override
+        protected void processDirectEntityShow(PlayerData playerData, EntityView<?> view, NettyEntity<?> entity, int worldEpoch) {
+            directlyShownEntityIDs.add(entity.entityID());
+            entity.setClientVisible(true);
+        }
+
+        @Override
+        protected void sendEntityPassengerPacket(int vehicle, IntArrayList passengers, PlayerData playerData) {
+            replacementPassengerPackets.add(passengers.toIntArray());
+        }
+
+        @Override
+        protected int processRelativeMovePacket(Void packet, PlayerData playerData, int currentTick) {
+            return -1;
+        }
+
+        @Override
+        protected int processRelativeMoveAndRotationPacket(Void packet, PlayerData playerData, int currentTick) {
+            return -1;
+        }
+
+        @Override
+        protected int processTeleportPacket(Void packet, PlayerData playerData, int currentTick) {
+            return -1;
+        }
+
+        @Override
+        protected int processPositionSyncPacket(Void packet, PlayerData playerData, int currentTick) {
+            return -1;
+        }
+
+        @Override
+        protected void cachePacket(Void packet, int entityID, PlayerData playerData, int currentTick) {}
+
+        @Override
+        protected int processRotationPacket(Void packet, PlayerData playerData, int currentTick) {
+            return -1;
+        }
+
+        @Override
+        protected int processHeadLookPacket(Void packet, PlayerData playerData, int currentTick) {
+            return -1;
+        }
+
+        @Override
+        protected int processEntityVelocityPacket(Void packet, PlayerData playerData, int currentTick) {
+            return -1;
+        }
+
+        @Override
+        protected void insertEntityToPlayerView(NettyEntity<?> entity, PlayerData playerData, UUID world) {}
+
+        @Override
+        protected void insertEntityToEntityView(NettyEntity<?> entity, PlayerData playerData, UUID world) {}
+    }
+
+    private static final class TestEntity extends NettyEntity<Clearable> {
+        private TestEntity(PlayerData owningPlayer, int entityID, UUID entityUUID) {
+            super(owningPlayer, entityID, entityUUID);
+        }
+
+        private TestEntity(PlayerData owningPlayer, int entityID, UUID entityUUID, boolean visible) {
+            super(owningPlayer, 0, 0, 0, entityID, entityUUID, false, 0, visible);
+        }
+
+        private static TestEntity createSelf(PlayerData owningPlayer, int entityID, UUID playerUUID) {
+            return new TestEntity(owningPlayer, entityID, playerUUID);
+        }
+    }
+}

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityView.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityView.java
@@ -8,7 +8,6 @@
 
 package games.cubi.raycastedantiesp.packetevents.view;
 
-import ca.spottedleaf.concurrentutil.collection.MultiThreadedQueue;
 import ca.spottedleaf.concurrentutil.map.SWMRHashTable;
 import games.cubi.locatables.api.Spatial;
 import games.cubi.logs.Logger;
@@ -17,6 +16,7 @@ import games.cubi.raycastedantiesp.core.players.PlayerData;
 import games.cubi.raycastedantiesp.core.utils.SingleThreadedGuard;
 import games.cubi.raycastedantiesp.core.view.EntityView;
 import games.cubi.raycastedantiesp.core.view.EntityViewTransition;
+import games.cubi.raycastedantiesp.core.view.PackedEntityTransitionQueue;
 import games.cubi.raycastedantiesp.packetevents.tracked.PacketEventsEntity;
 import it.unimi.dsi.fastutil.ints.Int2ObjectOpenHashMap;
 import org.jetbrains.annotations.NotNull;
@@ -28,7 +28,7 @@ import java.util.function.IntSupplier;
 public class PacketEventsEntityView extends SingleThreadedGuard implements EntityView<PacketEventsEntity> {
     private final SWMRHashTable<UUID, PacketEventsEntity> entitiesByUUID = new SWMRHashTable<>();
     private final Int2ObjectOpenHashMap<UUID> entityUUIDsByID = new Int2ObjectOpenHashMap<>();
-    private final MultiThreadedQueue<EntityViewTransition> transitions = new MultiThreadedQueue<>();
+    private final PackedEntityTransitionQueue transitions = new PackedEntityTransitionQueue();
     private final boolean isPlayerView;
     private final IntSupplier worldEpochSupplier;
     private UUID trackedWorld;
@@ -160,23 +160,33 @@ public class PacketEventsEntityView extends SingleThreadedGuard implements Entit
 
     @Override
     public void setVisibility(@NotNull NettyEntity<?> entity, boolean visible, int currentTick, int expectedWorldEpoch) {
-        if (!isCurrentWorldEpoch(expectedWorldEpoch)) {
-            return;
-        }
-        if (entitiesByUUID.get(entity.entityUUID()) != entity) {
-            return;
-        }
-        if (entity.isSelfEntity()) return;
         boolean visibilityChanged = entity.visible() != visible;
-        entity.setVisible(visible);
-        entity.setLastChecked(currentTick);
+        if (!recordDirectVisibility(entity, visible, currentTick, expectedWorldEpoch)) {
+            return;
+        }
         if (visibilityChanged) {
-            transitions.add(new EntityViewTransition(
+            transitions.add(
                     visible ? EntityViewTransition.Type.SHOW : EntityViewTransition.Type.HIDE,
                     entity,
                     expectedWorldEpoch
-            ));
+            );
         }
+    }
+
+    @Override
+    public boolean recordDirectVisibility(@NotNull NettyEntity<?> entity, boolean visible, int currentTick, int expectedWorldEpoch) {
+        if (!isCurrentWorldEpoch(expectedWorldEpoch)) {
+            return false;
+        }
+        if (entitiesByUUID.get(entity.entityUUID()) != entity) {
+            return false;
+        }
+        if (entity.isSelfEntity()) {
+            return false;
+        }
+        entity.setVisible(visible);
+        entity.setLastChecked(currentTick);
+        return true;
     }
 
     @Override
@@ -230,17 +240,17 @@ public class PacketEventsEntityView extends SingleThreadedGuard implements Entit
 
     @Override
     public boolean hasPendingTransitions() {
-        return !transitions.isEmpty();
+        return transitions.hasPendingTransitions();
     }
 
     @Override
-    public List<EntityViewTransition> drainTransitions() {
-        List<EntityViewTransition> drained = new ArrayList<>();
-        EntityViewTransition transition;
-        while ((transition = transitions.poll()) != null) {
-            drained.add(transition);
-        }
-        return drained;
+    public void flushPendingTransitions() {
+        transitions.flushPendingTransitions();
+    }
+
+    @Override
+    public void drainTransitions(EntityView.TransitionConsumer consumer) {
+        transitions.drainTransitions(consumer);
     }
 
     @Override
@@ -267,7 +277,7 @@ public class PacketEventsEntityView extends SingleThreadedGuard implements Entit
     private void clearTrackedState() {
         entitiesByUUID.clear();
         entityUUIDsByID.clear();
-        transitions.clear();
+        transitions.clearPublishedTransitions();
     }
 
     private boolean isCurrentWorldEpoch(int expectedWorldEpoch) {

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityView.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityView.java
@@ -129,7 +129,10 @@ public class PacketEventsEntityView extends SingleThreadedGuard implements Entit
 
     @Override
     public boolean isVisible(int entityID) {
-        PacketEventsEntity entity = Logger.requireNonNull(getTrackedEntity(entityID), "Entity with ID " + entityID + " does not exist in EntityView", 3, PacketEventsEntityView.class);
+        PacketEventsEntity entity = getTrackedEntity(entityID);
+        if (entity == null) {
+            Logger.errorAndReturn(new RuntimeException("Entity with ID " + entityID + " does not exist in EntityView"), 3, PacketEventsEntityView.class);
+        }
         return entity.visible();
     }
 

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityView.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityView.java
@@ -138,8 +138,7 @@ public class PacketEventsEntityView extends SingleThreadedGuard implements Entit
 
     @Override
     public Spatial getPosition(UUID entityUUID) {
-        PacketEventsEntity entity = entitiesByUUID.get(entityUUID);
-        return entity == null ? null : entity.getOffsetPosition();
+        return entitiesByUUID.get(entityUUID);
     }
 
     @Override

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewController.java
@@ -80,9 +80,8 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
         int currentTick = currentTickSupplier.getAsInt();
         boolean tileChecksEnabled = tileEntityConfig.enabled();
         BlockView blockView = playerData.blockView();
-        for (TrackedTileEntity<?> tileEntity : blockView.applyTileEntityCheckMode(tileChecksEnabled, currentTick)) {
-            sendTileEntityVisibilityRepair(event.getUser(), tileEntity);
-        }
+        blockView.applyTileEntityCheckMode(tileChecksEnabled, currentTick,
+                tileEntity -> sendTileEntityVisibilityRepair(event.getUser(), tileEntity));
 
         handleBlockPackets(event, event.getUser(), playerData, world, currentTick, tileChecksEnabled);
 

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewController.java
@@ -79,11 +79,14 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
         UUID world = common.resolvePacketWorld(playerData, event.getUser());
         int currentTick = currentTickSupplier.getAsInt();
         boolean tileChecksEnabled = tileEntityConfig.enabled();
-        playerData.blockView().applyTileEntityCheckMode(tileChecksEnabled, currentTick);
+        BlockView blockView = playerData.blockView();
+        for (TrackedTileEntity<?> tileEntity : blockView.applyTileEntityCheckMode(tileChecksEnabled, currentTick)) {
+            sendTileEntityVisibilityRepair(event.getUser(), tileEntity);
+        }
 
         handleBlockPackets(event, event.getUser(), playerData, world, currentTick, tileChecksEnabled);
 
-        if (playerData.blockView().hasPendingTransitions()) {
+        if (blockView.hasPendingTransitions()) {
             processTileEntityTransitions(event.getUser(), playerData);
         }
     }

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewController.java
@@ -165,35 +165,53 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
     private void processTileEntityTransitions(User viewer, PlayerData playerData) {
         BlockView blockView = playerData.blockView();
         int worldEpoch = playerData.acquireWorldEpoch();
-        for (BlockViewTransition transition : blockView.drainTransitions()) {
-            BlockSpatial location = transition.tileEntity();
-            TrackedTileEntity<PacketEventsTileEntityReplayData> state = resolveCurrentTransitionState(transition, worldEpoch);
-            if (state == null || state.blockID() == 0) {
-                continue;
-            }
-            switch (transition.type()) {
-                case HIDE -> {
-                    if (!blockView.isCurrentEnabledTileEntityMode(transition.modeToken())) {
-                        state.setVisible(true);
-                        state.setLastChecked(TrackedTileEntity.NEVER_CHECKED);
-                        continue;
-                    }
-                    viewer.writePacketSilently(new WrapperPlayServerBlockChange(
-                            new Vector3i(location.blockX(), location.blockY(), location.blockZ()),
-                            getHiddenBlockId(location.blockY())
-                    ));
+        blockView.drainTransitions((type, tileEntity, modeToken, transitionWorldEpoch) ->
+                processTileEntityTransition(viewer, blockView, worldEpoch, type, tileEntity, modeToken, transitionWorldEpoch));
+    }
+
+    private void processTileEntityTransition(User viewer, BlockView blockView, int worldEpoch,
+            BlockViewTransition.Type type, TrackedTileEntity<?> tileEntity, long modeToken, int transitionWorldEpoch) {
+        TrackedTileEntity<PacketEventsTileEntityReplayData> state = resolveCurrentTransitionState(tileEntity, transitionWorldEpoch, worldEpoch);
+        if (state == null || state.blockID() == 0) {
+            return;
+        }
+        switch (type) {
+            case HIDE -> {
+                if (!blockView.isCurrentEnabledTileEntityMode(modeToken)) {
+                    state.setVisible(true);
+                    state.setLastChecked(TrackedTileEntity.NEVER_CHECKED);
+                    return;
                 }
-                case SHOW -> {
-                    viewer.writePacketSilently(new WrapperPlayServerBlockChange(
-                            new Vector3i(location.blockX(), location.blockY(), location.blockZ()),
-                            state.blockID()
-                    ));
-                    PacketEventsTileEntityReplayData replayData = ensureTileReplayData(state);
-                    if (replayData.blockEntityType() != null && replayData.nbt() != null) {
-                        viewer.writePacketSilently(buildBlockEntityDataPacket(location, replayData));
-                    }
-                }
+                viewer.writePacketSilently(new WrapperPlayServerBlockChange(
+                        new Vector3i(tileEntity.blockX(), tileEntity.blockY(), tileEntity.blockZ()),
+                        getHiddenBlockId(tileEntity.blockY())
+                ));
             }
+            case SHOW -> {
+                if (!state.visible()) {
+                    return;
+                }
+                sendTileEntity(viewer, state);
+            }
+        }
+    }
+
+    @SuppressWarnings("unchecked")
+    private void sendTileEntityVisibilityRepair(User viewer, TrackedTileEntity<?> tileEntity) {
+        TrackedTileEntity<PacketEventsTileEntityReplayData> state = (TrackedTileEntity<PacketEventsTileEntityReplayData>) tileEntity;
+        if (state.blockID() != 0) {
+            sendTileEntity(viewer, state);
+        }
+    }
+
+    private void sendTileEntity(User viewer, TrackedTileEntity<PacketEventsTileEntityReplayData> tileEntity) {
+        viewer.writePacketSilently(new WrapperPlayServerBlockChange(
+                new Vector3i(tileEntity.blockX(), tileEntity.blockY(), tileEntity.blockZ()),
+                tileEntity.blockID()
+        ));
+        PacketEventsTileEntityReplayData replayData = ensureTileReplayData(tileEntity);
+        if (replayData.blockEntityType() != null && replayData.nbt() != null) {
+            viewer.writePacketSilently(buildBlockEntityDataPacket(tileEntity, replayData));
         }
     }
 
@@ -250,12 +268,18 @@ public abstract class PacketEventsBlockViewController implements PacketListener 
 
     @SuppressWarnings("unchecked")
     static @Nullable TrackedTileEntity<PacketEventsTileEntityReplayData> resolveCurrentTransitionState(BlockViewTransition transition, int currentWorldEpoch) {
-        if (transition.worldEpoch() != currentWorldEpoch
-                || !(transition.tileEntity() instanceof NettyTileEntity<?> tileEntity)
-                || tileEntity.isRemoved()) {
+        return resolveCurrentTransitionState(transition.tileEntity(), transition.worldEpoch(), currentWorldEpoch);
+    }
+
+    @SuppressWarnings("unchecked")
+    static @Nullable TrackedTileEntity<PacketEventsTileEntityReplayData> resolveCurrentTransitionState(
+            TrackedTileEntity<?> tileEntity, int transitionWorldEpoch, int currentWorldEpoch) {
+        if (transitionWorldEpoch != currentWorldEpoch
+                || !(tileEntity instanceof NettyTileEntity<?> nettyTileEntity)
+                || nettyTileEntity.isRemoved()) {
             return null;
         }
-        return (TrackedTileEntity<PacketEventsTileEntityReplayData>) transition.tileEntity();
+        return (TrackedTileEntity<PacketEventsTileEntityReplayData>) tileEntity;
     }
 
     private PacketEventsTileEntityReplayData ensureTileReplayData(TrackedTileEntity<PacketEventsTileEntityReplayData> tileEntity) {

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
@@ -298,6 +298,13 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
     }
 
     @Override
+    protected void processDirectEntityShow(PlayerData playerData, EntityView<?> view, NettyEntity<?> entity, int worldEpoch) {
+        Object channel = PacketEvents.getAPI().getProtocolManager().getChannel(playerData.getPlayerUUID());
+        User viewer = PacketEvents.getAPI().getProtocolManager().getUser(channel);
+        processEntityTransition(playerData, viewer, cast(view), worldEpoch, EntityViewTransition.Type.SHOW, entity, worldEpoch);
+    }
+
+    @Override
     protected @NotNull NettyEntity<?> processEntitySpawn(PlayerData playerData, PacketWrapper<?> packetWrapper, UUID world, int currentTick) {
         WrapperPlayServerSpawnEntity packet = (WrapperPlayServerSpawnEntity) packetWrapper;
         if (packet.getUUID().isEmpty()) {

--- a/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
+++ b/packetevents/src/main/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsEntityViewController.java
@@ -28,6 +28,7 @@ import games.cubi.logs.Logger;
 import games.cubi.raycastedantiesp.core.config.raycast.EntityTypeExclusions;
 import games.cubi.raycastedantiesp.core.entity.EntityBypassRegistry;
 import games.cubi.raycastedantiesp.core.tracked.NettyEntity;
+import games.cubi.raycastedantiesp.core.tracked.TrackedEntity;
 import games.cubi.raycastedantiesp.core.players.PlayerData;
 import games.cubi.raycastedantiesp.core.players.PlayerRegistry;
 import games.cubi.raycastedantiesp.core.utils.PrimitiveIntArrayList;
@@ -473,39 +474,43 @@ public abstract class PacketEventsEntityViewController extends PacketEntityViewC
 
     private void processEntityTransitions(PlayerData data, User viewer, EntityView<PacketEventsEntity> entityView) {
         int worldEpoch = data.acquireWorldEpoch(); //epoch can only change on the netty thread, so the epoch cannot be invalidated between this read and the packets being written
-        for (EntityViewTransition transition : entityView.drainTransitions()) {
-            if (!(transition.entity() instanceof PacketEventsEntity entity)
-                    || transition.worldEpoch() != worldEpoch
-                    || entityView.getEntity(entity.entityUUID()) != entity) {
-                continue;
-            }
+        entityView.drainTransitions((type, transitionEntity, transitionWorldEpoch) -> processEntityTransition(
+                data, viewer, entityView, worldEpoch, type, transitionEntity, transitionWorldEpoch));
+    }
 
-            if (entity.isSelfEntity()) {
-                Logger.warning("PacketEvents.processEntityTransitions skipped self entity viewer=" + data.getPlayerUUID()
-                        + " target=" + entity.entityUUID(), 2, PacketEventsEntityViewController.class);
-                continue;
-            }
-            if (!transitionMatchesCurrentVisibility(transition.type(), entity.visible())) {
-                continue;
-            }
+    private void processEntityTransition(PlayerData data, User viewer, EntityView<PacketEventsEntity> entityView,
+            int worldEpoch, EntityViewTransition.Type type, TrackedEntity<?> transitionEntity, int transitionWorldEpoch) {
+        if (!(transitionEntity instanceof PacketEventsEntity entity)
+                || transitionWorldEpoch != worldEpoch
+                || entityView.getEntity(entity.entityUUID()) != entity) {
+            return;
+        }
 
-            ClientTransitionAction action = resolveClientTransitionAction(
-                    transition.type(),
-                    entity.clientVisible(),
-                    getCorrectConfig(entityView).keepClientEntityWhenHidden()
-            );
-            switch (action) {
-                case DESTROY -> {
-                    viewer.writePacketSilently(new WrapperPlayServerDestroyEntities(entity.entityID()));
-                    entity.setClientVisible(false);
-                }
-                case SPAWN_AND_SYNC, SYNC -> {
-                    PacketEventsEntityReplayData replayData = ensureReplayData(entity);
-                    sendEntityShow(viewer, data, entity, replayData, action == ClientTransitionAction.SPAWN_AND_SYNC);
-                    entity.setClientVisible(true);
-                }
-                case NONE -> {}
+        if (entity.isSelfEntity()) {
+            Logger.warning("PacketEvents.processEntityTransitions skipped self entity viewer=" + data.getPlayerUUID()
+                    + " target=" + entity.entityUUID(), 2, PacketEventsEntityViewController.class);
+            return;
+        }
+        if (!transitionMatchesCurrentVisibility(type, entity.visible())) {
+            return;
+        }
+
+        ClientTransitionAction action = resolveClientTransitionAction(
+                type,
+                entity.clientVisible(),
+                getCorrectConfig(entityView).keepClientEntityWhenHidden()
+        );
+        switch (action) {
+            case DESTROY -> {
+                viewer.writePacketSilently(new WrapperPlayServerDestroyEntities(entity.entityID()));
+                entity.setClientVisible(false);
             }
+            case SPAWN_AND_SYNC, SYNC -> {
+                PacketEventsEntityReplayData replayData = ensureReplayData(entity);
+                sendEntityShow(viewer, data, entity, replayData, action == ClientTransitionAction.SPAWN_AND_SYNC);
+                entity.setClientVisible(true);
+            }
+            case NONE -> {}
         }
     }
 

--- a/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityViewTest.java
+++ b/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/view/PacketEventsEntityViewTest.java
@@ -14,11 +14,11 @@ import games.cubi.raycastedantiesp.packetevents.replaydata.PacketEventsEntityRep
 import org.junit.jupiter.api.Test;
 
 import java.time.Duration;
-import java.util.List;
 import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
 import static org.junit.jupiter.api.Assertions.assertArrayEquals;
@@ -129,6 +129,21 @@ class PacketEventsEntityViewTest {
     }
 
     @Test
+    void directVisibilityDoesNotPublishEngineTransition() {
+        AtomicInteger worldEpoch = new AtomicInteger(2);
+        PacketEventsEntityView view = PacketEventsEntityView.createEntityView(worldEpoch::getAcquire);
+        PacketEventsEntity entity = entity(1, UUID.randomUUID());
+        entity.setVisible(false);
+        view.insertEntity(UUID.randomUUID(), entity);
+
+        assertTrue(view.recordDirectVisibility(entity, true, 1, worldEpoch.getAcquire()));
+
+        assertTrue(entity.visible());
+        assertEquals(1, entity.lastChecked());
+        assertFalse(view.hasPendingTransitions());
+    }
+
+    @Test
     void currentEntityTransitionRetainsIdentityAndEpoch() {
         AtomicInteger worldEpoch = new AtomicInteger(2);
         PacketEventsEntityView view = PacketEventsEntityView.createEntityView(worldEpoch::getAcquire);
@@ -138,10 +153,19 @@ class PacketEventsEntityViewTest {
         int epoch = worldEpoch.getAcquire();
 
         view.setVisibility(entity, false, 1, epoch);
-        EntityViewTransition transition = view.drainTransitions().getFirst();
+        view.flushPendingTransitions();
+        AtomicReference<EntityViewTransition.Type> transitionType = new AtomicReference<>();
+        AtomicReference<PacketEventsEntity> transitionEntity = new AtomicReference<>();
+        AtomicInteger transitionWorldEpoch = new AtomicInteger();
+        view.drainTransitions((type, queuedEntity, queuedWorldEpoch) -> {
+            transitionType.set(type);
+            transitionEntity.set((PacketEventsEntity) queuedEntity);
+            transitionWorldEpoch.set(queuedWorldEpoch);
+        });
 
-        assertSame(entity, transition.entity());
-        assertEquals(epoch, transition.worldEpoch());
+        assertSame(entity, transitionEntity.get());
+        assertEquals(epoch, transitionWorldEpoch.get());
+        assertEquals(EntityViewTransition.Type.HIDE, transitionType.get());
         assertFalse(entity.visible());
         assertEquals(1, entity.lastChecked());
     }
@@ -160,22 +184,27 @@ class PacketEventsEntityViewTest {
             Thread producer = Thread.startVirtualThread(() -> {
                 for (int tick = 1; tick <= transitions; tick++) {
                     view.setVisibility(entity, (tick & 1) == 0, tick, worldEpoch.getAcquire());
+                    view.flushPendingTransitions();
                     while (acknowledgedTick.getAcquire() != tick) {
                         Thread.onSpinWait();
                     }
                 }
             });
 
+            AtomicReference<EntityViewTransition.Type> transitionType = new AtomicReference<>();
+            boolean[] drained = {false};
             for (int tick = 1; tick <= transitions; tick++) {
-                List<EntityViewTransition> drained;
                 do {
-                    drained = view.drainTransitions();
-                    if (drained.isEmpty()) Thread.onSpinWait();
-                } while (drained.isEmpty());
+                    drained[0] = false;
+                    view.drainTransitions((type, queuedEntity, worldEpochValue) -> {
+                        transitionType.set(type);
+                        drained[0] = true;
+                    });
+                    if (!drained[0]) Thread.onSpinWait();
+                } while (!drained[0]);
 
-                assertEquals(1, drained.size());
                 boolean expectedVisible = (tick & 1) == 0;
-                assertEquals(expectedVisible ? EntityViewTransition.Type.SHOW : EntityViewTransition.Type.HIDE, drained.getFirst().type());
+                assertEquals(expectedVisible ? EntityViewTransition.Type.SHOW : EntityViewTransition.Type.HIDE, transitionType.get());
                 assertEquals(expectedVisible, entity.visible());
                 assertEquals(tick, entity.lastChecked());
                 acknowledgedTick.setRelease(tick);

--- a/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewControllerTest.java
+++ b/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewControllerTest.java
@@ -4,12 +4,13 @@ import games.cubi.locatables.implementations.ImmutableBlockSpatialImpl;
 import games.cubi.raycastedantiesp.core.chunks.BlockInfoResolver;
 import games.cubi.raycastedantiesp.core.tracked.NettyTileEntity;
 import games.cubi.raycastedantiesp.core.tracked.TrackedTileEntity;
-import games.cubi.raycastedantiesp.core.view.BlockViewTransition;
+import games.cubi.raycastedantiesp.core.view.BlockView;
 import games.cubi.raycastedantiesp.packetevents.view.PacketEventsBlockView;
 import org.junit.jupiter.api.Test;
 
 import java.util.UUID;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.IntSupplier;
 
 import static org.junit.jupiter.api.Assertions.assertEquals;
@@ -34,19 +35,21 @@ class PacketEventsBlockViewControllerTest {
         view.applyTileEntityCheckMode(true, 0);
         view.updateOrInsertTileEntity(world, location, (char) 1, true);
         TrackedTileEntity<?> original = view.getTrackedTileEntity(world, location);
-        view.applyTileEntityVisibilityDecision(original, false, 1, view.tileEntityCheckModeToken(), 2);
-        BlockViewTransition transition = view.drainTransitions().getFirst();
+        view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), 2, ignored -> BlockView.VisibilityResolver.HIDE);
+        view.flushPendingTransitions();
+        AtomicReference<TrackedTileEntity<?>> transitionEntity = new AtomicReference<>();
+        view.drainTransitions((type, tileEntity, modeToken, worldEpoch) -> transitionEntity.set(tileEntity));
 
         view.removeTileEntity(world, location);
         view.updateOrInsertTileEntity(world, location, (char) 2, true);
         TrackedTileEntity<?> replacement = view.getTrackedTileEntity(world, location);
         int replacementLastChecked = replacement.lastChecked();
 
-        assertSame(original, transition.tileEntity());
+        assertSame(original, transitionEntity.get());
         assertTrue(((NettyTileEntity<?>) original).isRemoved());
         original.setLastChecked(42);
         assertTrue(((NettyTileEntity<?>) original).isRemoved());
-        assertNull(PacketEventsBlockViewController.resolveCurrentTransitionState(transition, 2));
+        assertNull(PacketEventsBlockViewController.resolveCurrentTransitionState(transitionEntity.get(), 2, 2));
         assertTrue(replacement.visible());
         assertEquals(replacementLastChecked, replacement.lastChecked());
     }
@@ -58,10 +61,12 @@ class PacketEventsBlockViewControllerTest {
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, STABLE_WORLD_EPOCH);
         view.applyTileEntityCheckMode(true, 0);
         TrackedTileEntity<?> tileEntity = view.updateOrInsertTileEntity(world, location, (char) 1, true);
-        view.applyTileEntityVisibilityDecision(tileEntity, false, 1, view.tileEntityCheckModeToken(), 2);
-        BlockViewTransition transition = view.drainTransitions().getFirst();
+        view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), 2, ignored -> BlockView.VisibilityResolver.HIDE);
+        view.flushPendingTransitions();
+        AtomicReference<TrackedTileEntity<?>> transitionEntity = new AtomicReference<>();
+        view.drainTransitions((type, queuedTileEntity, modeToken, worldEpoch) -> transitionEntity.set(queuedTileEntity));
 
-        assertSame(transition.tileEntity(), PacketEventsBlockViewController.resolveCurrentTransitionState(transition, 2));
+        assertSame(transitionEntity.get(), PacketEventsBlockViewController.resolveCurrentTransitionState(transitionEntity.get(), 2, 2));
     }
 
     @Test
@@ -71,15 +76,17 @@ class PacketEventsBlockViewControllerTest {
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, STABLE_WORLD_EPOCH);
         view.applyTileEntityCheckMode(true, 0);
         TrackedTileEntity<?> original = view.updateOrInsertTileEntity(world, location, (char) 1, false);
-        view.applyTileEntityVisibilityDecision(original, true, 1, view.tileEntityCheckModeToken(), 2);
-        BlockViewTransition transition = view.drainTransitions().getFirst();
+        view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), 2, ignored -> BlockView.VisibilityResolver.SHOW);
+        view.flushPendingTransitions();
+        AtomicReference<TrackedTileEntity<?>> transitionEntity = new AtomicReference<>();
+        view.drainTransitions((type, tileEntity, modeToken, worldEpoch) -> transitionEntity.set(tileEntity));
 
         view.removeTileEntity(world, location);
         view.updateOrInsertTileEntity(world, location, (char) 2, false);
         TrackedTileEntity<?> replacement = view.getTrackedTileEntity(world, location);
         int replacementLastChecked = replacement.lastChecked();
 
-        assertNull(PacketEventsBlockViewController.resolveCurrentTransitionState(transition, 2));
+        assertNull(PacketEventsBlockViewController.resolveCurrentTransitionState(transitionEntity.get(), 2, 2));
         assertFalse(replacement.visible());
         assertEquals(replacementLastChecked, replacement.lastChecked());
     }
@@ -93,13 +100,20 @@ class PacketEventsBlockViewControllerTest {
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, worldEpoch::getAcquire);
         view.applyTileEntityCheckMode(true, 0);
         TrackedTileEntity<?> original = view.updateOrInsertTileEntity(firstWorld, position, (char) 1, true);
-        view.applyTileEntityVisibilityDecision(original, false, 1, view.tileEntityCheckModeToken(), worldEpoch.getAcquire());
-        BlockViewTransition transition = view.drainTransitions().getFirst();
+        view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), worldEpoch.getAcquire(), ignored -> BlockView.VisibilityResolver.HIDE);
+        view.flushPendingTransitions();
+        AtomicReference<TrackedTileEntity<?>> transitionEntity = new AtomicReference<>();
+        AtomicInteger transitionWorldEpoch = new AtomicInteger();
+        view.drainTransitions((type, tileEntity, modeToken, queuedWorldEpoch) -> {
+            transitionEntity.set(tileEntity);
+            transitionWorldEpoch.set(queuedWorldEpoch);
+        });
 
         worldEpoch.setRelease(4);
         TrackedTileEntity<?> replacement = view.updateOrInsertTileEntity(secondWorld, position, (char) 2, true);
 
-        assertNull(PacketEventsBlockViewController.resolveCurrentTransitionState(transition, worldEpoch.getAcquire()));
+        assertNull(PacketEventsBlockViewController.resolveCurrentTransitionState(
+                transitionEntity.get(), transitionWorldEpoch.get(), worldEpoch.getAcquire()));
         assertTrue(replacement.visible());
     }
 }

--- a/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewControllerTest.java
+++ b/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/PacketEventsBlockViewControllerTest.java
@@ -32,7 +32,7 @@ class PacketEventsBlockViewControllerTest {
         UUID world = UUID.randomUUID();
         ImmutableBlockSpatialImpl location = new ImmutableBlockSpatialImpl(3, 64, 5);
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, STABLE_WORLD_EPOCH);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         view.updateOrInsertTileEntity(world, location, (char) 1, true);
         TrackedTileEntity<?> original = view.getTrackedTileEntity(world, location);
         view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), 2, ignored -> BlockView.VisibilityResolver.HIDE);
@@ -59,7 +59,7 @@ class PacketEventsBlockViewControllerTest {
         UUID world = UUID.randomUUID();
         ImmutableBlockSpatialImpl location = new ImmutableBlockSpatialImpl(3, 64, 5);
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, STABLE_WORLD_EPOCH);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         TrackedTileEntity<?> tileEntity = view.updateOrInsertTileEntity(world, location, (char) 1, true);
         view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), 2, ignored -> BlockView.VisibilityResolver.HIDE);
         view.flushPendingTransitions();
@@ -74,7 +74,7 @@ class PacketEventsBlockViewControllerTest {
         UUID world = UUID.randomUUID();
         ImmutableBlockSpatialImpl location = new ImmutableBlockSpatialImpl(3, 64, 5);
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, STABLE_WORLD_EPOCH);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         TrackedTileEntity<?> original = view.updateOrInsertTileEntity(world, location, (char) 1, false);
         view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), 2, ignored -> BlockView.VisibilityResolver.SHOW);
         view.flushPendingTransitions();
@@ -98,7 +98,7 @@ class PacketEventsBlockViewControllerTest {
         ImmutableBlockSpatialImpl position = new ImmutableBlockSpatialImpl(3, 64, 5);
         AtomicInteger worldEpoch = new AtomicInteger(2);
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, worldEpoch::getAcquire);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         TrackedTileEntity<?> original = view.updateOrInsertTileEntity(firstWorld, position, (char) 1, true);
         view.updateVisibilityForEachNeedingRecheck(0, 1, view.tileEntityCheckModeToken(), worldEpoch.getAcquire(), ignored -> BlockView.VisibilityResolver.HIDE);
         view.flushPendingTransitions();

--- a/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/chunkparser/ChunkParserTest.java
+++ b/packetevents/src/test/java/games/cubi/raycastedantiesp/packetevents/viewcontrollers/chunkparser/ChunkParserTest.java
@@ -87,7 +87,7 @@ class ChunkParserTest {
         TileEntity tileEntity = new TileEntity((byte) (3 << 4 | 1), (short) 2, 0, null);
         Column column = new Column(0, 0, true, new BaseChunk[]{section}, new TileEntity[]{tileEntity});
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, STABLE_WORLD_EPOCH);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
 
         Column replacement = new BlockChunkParser(RESOLVER, ignored -> 1).parse(view, world, column, 0);
 
@@ -142,7 +142,7 @@ class ChunkParserTest {
         Column initialColumn = new Column(0, 0, true, new BaseChunk[]{initial}, new TileEntity[]{tile});
         new NonMutatingBlockChunkParser(RESOLVER, ignored -> 1).parse(view, world, initialColumn, 0);
 
-        view.applyTileEntityCheckMode(true, 1);
+        view.applyTileEntityCheckMode(true, 1, unused -> {});
         Chunk_v1_18 resend = airSection();
         resend.set(3, 2, 1, 99);
         Column resendColumn = new Column(0, 0, true, new BaseChunk[]{resend}, new TileEntity[]{tile});
@@ -220,7 +220,7 @@ class ChunkParserTest {
         Chunk_v1_18 mutatingSection = airSection();
         mutatingSection.set(3, 2, 1, 99);
         PacketEventsBlockView mutatingView = new PacketEventsBlockView(RESOLVER, false, STABLE_WORLD_EPOCH);
-        mutatingView.applyTileEntityCheckMode(true, 0);
+        mutatingView.applyTileEntityCheckMode(true, 0, unused -> {});
         Column mutatingReplacement = new OcclusionChunkParser(RESOLVER, ignored -> 1).parse(
                 mutatingView, world, new Column(0, 0, true, new BaseChunk[]{mutatingSection}, new TileEntity[]{tile}), 0
         );
@@ -250,7 +250,7 @@ class ChunkParserTest {
     void mutatingParserCompactsManagedAndInvalidEntriesWhileRetainingUnmanagedData() {
         UUID world = UUID.randomUUID();
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, STABLE_WORLD_EPOCH);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         Chunk_v1_18 section = airSection();
         section.set(1, 2, 1, 99);
         section.set(2, 2, 2, 100);
@@ -296,7 +296,7 @@ class ChunkParserTest {
 
     private static PacketEventsBlockView enabledView() {
         PacketEventsBlockView view = new PacketEventsBlockView(RESOLVER, true, STABLE_WORLD_EPOCH);
-        view.applyTileEntityCheckMode(true, 0);
+        view.applyTileEntityCheckMode(true, 0, unused -> {});
         return view;
     }
 


### PR DESCRIPTION
I ran through the code with an allocation profiler and eliminated almost all short-lived object allocations. The most significant change was going from 2 object allocations per raycast to 0. A very invasive change was batching transitions since the object header overhead was a significant part of the object size, and a separate node for every change was also costly. Batching them reduced queue memory allocation by ~40%.